### PR TITLE
Add a timeScaleFactor API to the animator.

### DIFF
--- a/src/MDMMotionAnimator.h
+++ b/src/MDMMotionAnimator.h
@@ -28,6 +28,15 @@ NS_SWIFT_NAME(MotionAnimator)
 @interface MDMMotionAnimator : NSObject
 
 /**
+ The scaling factor to apply to all time-related values.
+
+ For example, a timeScaleFactor of 2 will double the length of all animations.
+
+ 1.0 by default.
+ */
+@property(nonatomic, assign) CGFloat timeScaleFactor;
+
+/**
  If enabled, all animations will be added with their values reversed.
 
  Disabled by default.

--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -32,7 +32,7 @@ static CGFloat simulatorAnimationDragCoefficient(void) {
 
 static CAMediaTimingFunction* timingFunctionWithControlPoints(CGFloat controlPoints[4]);
 static NSArray* coerceUIKitValuesToCoreAnimationValues(NSArray *values);
-static CABasicAnimation *animationFromTiming(MDMMotionTiming timing);
+static CABasicAnimation *animationFromTiming(MDMMotionTiming timing, CGFloat timeScaleFactor);
 static void makeAnimationAdditive(CABasicAnimation *animation);
 
 @implementation MDMMotionAnimator {
@@ -42,6 +42,7 @@ static void makeAnimationAdditive(CABasicAnimation *animation);
 - (instancetype)init {
   self = [super init];
   if (self) {
+    _timeScaleFactor = 1;
     _additive = true;
   }
   return self;
@@ -74,7 +75,8 @@ static void makeAnimationAdditive(CABasicAnimation *animation);
     return;
   }
 
-  CABasicAnimation *animation = animationFromTiming(timing);
+  CGFloat timeScaleFactor = simulatorAnimationDragCoefficient() * _timeScaleFactor;
+  CABasicAnimation *animation = animationFromTiming(timing, timeScaleFactor);
 
   if (animation) {
     animation.keyPath = keyPath;
@@ -100,7 +102,7 @@ static void makeAnimationAdditive(CABasicAnimation *animation);
 
       if (timing.delay != 0) {
         animation.beginTime = ([layer convertTime:CACurrentMediaTime() fromLayer:nil]
-                               + timing.delay * simulatorAnimationDragCoefficient());
+                               + timing.delay * timeScaleFactor);
         animation.fillMode = kCAFillModeBackwards;
       }
 
@@ -160,7 +162,7 @@ static NSArray* coerceUIKitValuesToCoreAnimationValues(NSArray *values) {
   return values;
 }
 
-static CABasicAnimation *animationFromTiming(MDMMotionTiming timing) {
+static CABasicAnimation *animationFromTiming(MDMMotionTiming timing, CGFloat timeScaleFactor) {
   CABasicAnimation *animation;
   switch (timing.curve.type) {
     case MDMMotionCurveTypeInstant:
@@ -171,7 +173,7 @@ static CABasicAnimation *animationFromTiming(MDMMotionTiming timing) {
     case MDMMotionCurveTypeBezier:
       animation = [CABasicAnimation animation];
       animation.timingFunction = timingFunctionWithControlPoints(timing.curve.data);
-      animation.duration = timing.duration * simulatorAnimationDragCoefficient();
+      animation.duration = timing.duration * timeScaleFactor;
       break;
 
     case MDMMotionCurveTypeSpring: {


### PR DESCRIPTION
This API allows you to scale the durations and delay of all animations. It can also be used to build animations that make use of relative time, e.g. durations/delays in terms of 0-1 and timeScaleFactor the actual duration.

Closes #4 