### PR TITLE
Extract a MDMCoreAnimationTraceable protocol from MotionAnimator.

### DIFF
--- a/src/MDMCoreAnimationTraceable.h
+++ b/src/MDMCoreAnimationTraceable.h
@@ -1,0 +1,30 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+/**
+ An object conforming to this protocol allows registration of tracers for the purposes of debugging
+ Core Animation animations.
+ */
+@protocol MDMCoreAnimationTraceable
+
+/**
+ Adds a block that will be invoked each time an animation is added to a layer.
+ */
+- (void)addCoreAnimationTracer:(nonnull void (^)(CALayer * _Nonnull, CAAnimation * _Nonnull))tracer;
+
+@end

--- a/src/MDMMotionAnimator.h
+++ b/src/MDMMotionAnimator.h
@@ -20,12 +20,13 @@
 #import <MotionInterchange/MotionInterchange.h>
 
 #import "MDMAnimatableKeyPaths.h"
+#import "MDMCoreAnimationTraceable.h"
 
 /**
  An animator adds Core Animation animations to a layer based on a provided motion timing.
  */
 NS_SWIFT_NAME(MotionAnimator)
-@interface MDMMotionAnimator : NSObject
+@interface MDMMotionAnimator : NSObject <MDMCoreAnimationTraceable>
 
 /**
  The scaling factor to apply to all time-related values.
@@ -93,10 +94,5 @@ NS_SWIFT_NAME(MotionAnimator)
                withValues:(nonnull NSArray *)values
                   keyPath:(nonnull MDMAnimatableKeyPath)keyPath
                completion:(nullable void(^)(void))completion;
-
-/**
- Adds a block that will be invoked each time an animation is added to a layer.
- */
-- (void)addCoreAnimationTracer:(nonnull void (^)(CALayer * _Nonnull, CAAnimation * _Nonnull))tracer;
 
 @end


### PR DESCRIPTION
This allows us to reuse the protocol signature across different animator types.