### PR TITLE
Disable implicit animations when adding explicit animations in the animator

### DIFF
--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -112,7 +112,14 @@
     }
   }
 
+  [CATransaction begin];
+  BOOL actionsWereDisabled = [CATransaction disableActions];
+  [CATransaction setDisableActions:YES];
+
   [layer setValue:[values lastObject] forKeyPath:keyPath];
+
+  [CATransaction setDisableActions:actionsWereDisabled];
+  [CATransaction commit];
 }
 
 - (void)addCoreAnimationTracer:(void (^)(CALayer *, CAAnimation *))tracer {

--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -113,12 +113,8 @@
   }
 
   [CATransaction begin];
-  BOOL actionsWereDisabled = [CATransaction disableActions];
   [CATransaction setDisableActions:YES];
-
   [layer setValue:[values lastObject] forKeyPath:keyPath];
-
-  [CATransaction setDisableActions:actionsWereDisabled];
   [CATransaction commit];
 }
 

--- a/tests/unit/MotionAnimatorTests.swift
+++ b/tests/unit/MotionAnimatorTests.swift
@@ -47,5 +47,27 @@ class MotionAnimatorTests: XCTestCase {
     XCTAssertTrue(true)
   }
 
+  func testAnimatorOnlyAddsAnimationsForKeyPath() {
+    let animator = MotionAnimator()
+    let timing = MotionTiming(delay: 0,
+                              duration: 1,
+                              curve: .init(type: .bezier, data: (0, 0, 0, 0)),
+                              repetition: .init(type: .none, amount: 0, autoreverses: false))
+
+    let window = UIWindow()
+    window.makeKeyAndVisible()
+    let view = UIView() // Need to animate a view's layer to get implicit animations.
+    window.addSubview(view)
+
+    XCTAssertEqual(view.layer.delegate as? UIView, view)
+
+    UIView.animate(withDuration: 0.5) {
+      animator.animate(with: timing, to: view.layer, withValues: [0, 1], keyPath: .rotation)
+
+      // Setting transform.rotation.z will create an implicit transform if implicit animations
+      // aren't disabled by the animator properly, so verify that such an animation doesn't exist:
+      XCTAssertNil(view.layer.animation(forKey: "transform"))
+    }
+  }
 }
 


### PR DESCRIPTION
A client using the animator expects that it will only add animations for the key path that was specified, but it's possible that setting the final value for a given key path can create implicit animations. We now disable implicit animations when setting the final value to the layer.