### PR TITLE
Use <> framework import for MDMMotionAnimator.h in order to support module builds

### DIFF
--- a/src/MDMMotionAnimator.h
+++ b/src/MDMMotionAnimator.h
@@ -17,7 +17,7 @@
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
 
-#import "MotionInterchange.h"
+#import <MotionInterchange/MotionInterchange.h>
 
 #import "MDMAnimatableKeyPaths.h"
 #import "MDMCoreAnimationTraceable.h"


### PR DESCRIPTION
This is unfortunately required by CocoaPods. We'll have to explore an alternative approach for fixing bazel + kokoro imports (which required "" imports).