### PR TITLE
Attempting to fix downstream dependency issues.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -22,27 +22,6 @@ set -x
 
 KOKORO_RUNNER_VERSION="v3.*"
 
-fix_bazel_imports() {
-  if [ -z "$KOKORO_BUILD_NUMBER" ]; then
-    tests_dir_prefix=""
-  else
-    tests_dir_prefix="github/repo/"
-  fi
-
-  # Fixes a bug in bazel where objc_library targets have a _ prefix.
-  find "${tests_dir_prefix}tests/unit" -type f -name '*.swift' -exec sed -i '' -E "s/import Motion(.+)/import _Motion\1/" {} + || true
-  # CocoaPods requires that public headers of dependent pods be implemented using framework import
-  # notation, while bazel requires that dependency headers be imported with quoted notation.
-  find "${tests_dir_prefix}src" -type f -name '*.h' -exec sed -i '' -E "s/import <MotionInterchange\/MotionInterchange\.h>/import \"MotionInterchange.h\"/" {} + || true
-  stashed_dir=$(pwd)
-  reset_imports() {
-    # Undoes our source changes from above.
-    find "${stashed_dir}/${tests_dir_prefix}tests/unit" -type f -name '*.swift' -exec sed -i '' -E "s/import _Motion(.+)/import Motion\1/" {} + || true
-    find "${stashed_dir}/${tests_dir_prefix}src" -type f -name '*.h' -exec sed -i '' -E "s/import \"MotionInterchange.h\"/import <MotionInterchange\/MotionInterchange.h>/" {} + || true
-  }
-  trap reset_imports EXIT
-}
-
 if [ ! -d .kokoro-ios-runner ]; then
   git clone https://github.com/material-foundation/kokoro-ios-runner.git .kokoro-ios-runner
 fi
@@ -53,8 +32,6 @@ git fetch > /dev/null
 TAG=$(git tag --sort=v:refname -l "$KOKORO_RUNNER_VERSION" | tail -n1)
 git checkout "$TAG" > /dev/null
 popd
-
-fix_bazel_imports
 
 ./.kokoro-ios-runner/bazel.sh test //:UnitTests 8.1.0
 

--- a/BUILD
+++ b/BUILD
@@ -33,6 +33,7 @@ strict_warnings_objc_library(
         "src/*.h",
         "src/private/*.h",
     ]),
+    defines = ["IS_BAZEL_BUILD"],
     deps = [
       "@motion_interchange_objc//:MotionInterchange"
     ],
@@ -46,6 +47,7 @@ swift_library(
     srcs = glob([
         "tests/unit/*.swift",
     ]),
+    defines = ["IS_BAZEL_BUILD"],
     deps = [":MotionAnimator"],
     visibility = ["//visibility:private"],
 )

--- a/src/MDMMotionAnimator.h
+++ b/src/MDMMotionAnimator.h
@@ -17,7 +17,11 @@
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
 
+#ifdef IS_BAZEL_BUILD
+#import "MotionInterchange.h"
+#else
 #import <MotionInterchange/MotionInterchange.h>
+#endif
 
 #import "MDMAnimatableKeyPaths.h"
 #import "MDMCoreAnimationTraceable.h"

--- a/tests/unit/ImplicitAnimationTests.swift
+++ b/tests/unit/ImplicitAnimationTests.swift
@@ -15,8 +15,11 @@
  */
 
 import XCTest
-
+#if IS_BAZEL_BUILD
+import _MotionAnimator
+#else
 import MotionAnimator
+#endif
 
 class ImplicitAnimationTests: XCTestCase {
   var animator: MotionAnimator!

--- a/tests/unit/MotionAnimatorTests.swift
+++ b/tests/unit/MotionAnimatorTests.swift
@@ -15,7 +15,12 @@
  */
 
 import XCTest
+
+#if IS_BAZEL_BUILD
+import _MotionAnimator
+#else
 import MotionAnimator
+#endif
 
 class MotionAnimatorTests: XCTestCase {
 

--- a/tests/unit/TimeScaleFactorTests.swift
+++ b/tests/unit/TimeScaleFactorTests.swift
@@ -15,7 +15,11 @@
  */
 
 import XCTest
+#if IS_BAZEL_BUILD
+import _MotionAnimator
+#else
 import MotionAnimator
+#endif
 
 class TimeScaleFactorTests: XCTestCase {
 


### PR DESCRIPTION
Add `IS_BAZEL_BUILD` macro so that source can use different import statements during bazel builds.

This is unfortunately the only solution I can see for supporting both CocoaPods and bazel externally when there are dependencies of dependencies. In order for downstream dependencies (like Material Components) to depend on a library (MotionAnimator) that depends on another library (MotionInterchange), the middle library's imports need to reflect the desired bazel imports of the downstream library (MDC) at build time.

We'd previously been doing import manipulation at continuous integration time, but such manipulations can only be done on the local source and not on dependencies.