### PR TITLE
Extract initial velocity from the motion timing.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,5 +27,5 @@ git_repository(
 git_repository(
     name = "motion_interchange_objc",
     remote = "https://github.com/material-motion/motion-interchange-objc.git",
-    tag = "v1.2.0",
+    tag = "v1.3.0",
 )

--- a/examples/apps/Catalog/MotionAnimatorCatalog.xcodeproj/project.pbxproj
+++ b/examples/apps/Catalog/MotionAnimatorCatalog.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		2AA864EDA683CEF5FAA721BE /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2DBE814C7B88BAD6337052DB /* Pods_UnitTests.framework */; };
 		660636021FACC24300C3DFB8 /* TimeScaleFactorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660636011FACC24300C3DFB8 /* TimeScaleFactorTests.swift */; };
+		6625876C1FB4DB9C00BC7DF1 /* InitialVelocityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6625876B1FB4DB9C00BC7DF1 /* InitialVelocityTests.swift */; };
 		666FAA841D384A6B000363DA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666FAA831D384A6B000363DA /* AppDelegate.swift */; };
 		666FAA8B1D384A6B000363DA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 666FAA8A1D384A6B000363DA /* Assets.xcassets */; };
 		666FAA8E1D384A6B000363DA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 666FAA8C1D384A6B000363DA /* LaunchScreen.storyboard */; };
@@ -46,6 +47,7 @@
 		50D808A6F9E944D54276D32F /* Pods_MotionAnimatorCatalog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MotionAnimatorCatalog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52820916F8FAA40E942A7333 /* Pods-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.release.xcconfig"; path = "../../../Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
 		660636011FACC24300C3DFB8 /* TimeScaleFactorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeScaleFactorTests.swift; sourceTree = "<group>"; };
+		6625876B1FB4DB9C00BC7DF1 /* InitialVelocityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialVelocityTests.swift; sourceTree = "<group>"; };
 		666FAA801D384A6B000363DA /* MotionAnimatorCatalog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MotionAnimatorCatalog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		666FAA831D384A6B000363DA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Catalog/AppDelegate.swift; sourceTree = "<group>"; };
 		666FAA8A1D384A6B000363DA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 				66FD99F91EE9FBBE00C53A82 /* MotionAnimatorTests.m */,
 				668726491EF04B4C00113675 /* MotionAnimatorTests.swift */,
 				66BF5A8E1FB0E4CB00E864F6 /* ImplicitAnimationTests.swift */,
+				6625876B1FB4DB9C00BC7DF1 /* InitialVelocityTests.swift */,
 				660636011FACC24300C3DFB8 /* TimeScaleFactorTests.swift */,
 			);
 			path = unit;
@@ -485,6 +488,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6625876C1FB4DB9C00BC7DF1 /* InitialVelocityTests.swift in Sources */,
 				660636021FACC24300C3DFB8 /* TimeScaleFactorTests.swift in Sources */,
 				66BF5A8F1FB0E4CB00E864F6 /* ImplicitAnimationTests.swift in Sources */,
 				6687264A1EF04B4C00113675 /* MotionAnimatorTests.swift in Sources */,

--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -85,9 +85,7 @@
     animation.toValue = [values lastObject];
 
     if (![animation.fromValue isEqual:animation.toValue]) {
-      if (self.additive) {
-        MDMMakeAnimationAdditive(animation);
-      }
+      MDMConfigureAnimation(animation, self.additive, timing);
 
       if (timing.delay != 0) {
         animation.beginTime = ([layer convertTime:CACurrentMediaTime() fromLayer:nil]

--- a/src/private/CABasicAnimation+MotionAnimator.h
+++ b/src/private/CABasicAnimation+MotionAnimator.h
@@ -31,6 +31,6 @@ CABasicAnimation *MDMAnimationFromTiming(MDMMotionTiming timing, CGFloat timeSca
 // supported, the animation's values will not be modified.
 //
 // If the from and to values of the animation match then the behavior is undefined.
-FOUNDATION_EXPORT BOOL MDMConfigureAnimation(CABasicAnimation *animation,
+FOUNDATION_EXPORT void MDMConfigureAnimation(CABasicAnimation *animation,
                                              BOOL wantsAdditive,
                                              MDMMotionTiming timing);

--- a/src/private/CABasicAnimation+MotionAnimator.h
+++ b/src/private/CABasicAnimation+MotionAnimator.h
@@ -30,7 +30,7 @@ CABasicAnimation *MDMAnimationFromTiming(MDMMotionTiming timing, CGFloat timeSca
 // Not all animation value types support being additive. If an animation's value type was not
 // supported, the animation's values will not be modified.
 //
-// This method assumes that the animation's from and to value do not match.
-FOUNDATION_EXPORT void MDMConfigureAnimation(CABasicAnimation *animation,
+// If the from and to values of the animation match then the behavior is undefined.
+FOUNDATION_EXPORT BOOL MDMConfigureAnimation(CABasicAnimation *animation,
                                              BOOL wantsAdditive,
                                              MDMMotionTiming timing);

--- a/src/private/CABasicAnimation+MotionAnimator.h
+++ b/src/private/CABasicAnimation+MotionAnimator.h
@@ -24,7 +24,13 @@
 FOUNDATION_EXPORT
 CABasicAnimation *MDMAnimationFromTiming(MDMMotionTiming timing, CGFloat timeScaleFactor);
 
-// Attemps to configure the provided animation to be additive.
-// Not all animation value types are supported. If an animation's value type was not supported,
-// the animation will not be modified.
-FOUNDATION_EXPORT void MDMMakeAnimationAdditive(CABasicAnimation *animation);
+// Attempts to configure the provided animation to be additive and, if the animation is a spring
+// animation, will extract the initial velocity from the timing and apply it to the animation.
+//
+// Not all animation value types support being additive. If an animation's value type was not
+// supported, the animation's values will not be modified.
+//
+// This method assumes that the animation's from and to value do not match.
+FOUNDATION_EXPORT void MDMConfigureAnimation(CABasicAnimation *animation,
+                                             BOOL wantsAdditive,
+                                             MDMMotionTiming timing);

--- a/src/private/CABasicAnimation+MotionAnimator.m
+++ b/src/private/CABasicAnimation+MotionAnimator.m
@@ -132,7 +132,7 @@ void MDMConfigureAnimation(CABasicAnimation *animation,
       //
       // From the UIView animateWithDuration header docs:
       //
-      // "[initialVelocity is] a unit coordinate system, where 1 is defined as traveling the total
+      // "initialVelocity is a unit coordinate system, where 1 is defined as traveling the total
       //  animation distance in a second. So if you're changing an object's position by 200pt in
       //  this animation, and you want the animation to behave as if the object was moving at
       //  100pt/s before the animation started, you'd pass 0.5. You'll typically want to pass 0 for

--- a/src/private/CABasicAnimation+MotionAnimator.m
+++ b/src/private/CABasicAnimation+MotionAnimator.m
@@ -47,7 +47,6 @@ CABasicAnimation *MDMAnimationFromTiming(MDMMotionTiming timing, CGFloat timeSca
       spring.mass = timing.curve.data[MDMSpringMotionCurveDataIndexMass];
       spring.stiffness = timing.curve.data[MDMSpringMotionCurveDataIndexTension];
       spring.damping = timing.curve.data[MDMSpringMotionCurveDataIndexFriction];
-      spring.initialVelocity = timing.curve.data[MDMSpringMotionCurveDataIndexInitialVelocity];
 
       // This API is only available on iOS 9+
       if ([spring respondsToSelector:@selector(settlingDuration)]) {
@@ -62,23 +61,62 @@ CABasicAnimation *MDMAnimationFromTiming(MDMMotionTiming timing, CGFloat timeSca
   return animation;
 }
 
-void MDMMakeAnimationAdditive(CABasicAnimation *animation) {
+void MDMConfigureAnimation(CABasicAnimation *animation,
+                           BOOL wantsAdditive,
+                           MDMMotionTiming timing) {
+  if (!wantsAdditive && timing.curve.type != MDMMotionCurveTypeSpring) {
+    return; // Nothing to do here.
+  }
+
+  // We can't infer the from/to value types from the animation if the values are NSValue types, so
+  // we map known key paths to their data types here:
   static NSSet *sizeKeyPaths = nil;
   static NSSet *positionKeyPaths = nil;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     sizeKeyPaths = [NSSet setWithArray:@[@"bounds.size"]];
-
-    positionKeyPaths = [NSSet setWithArray:@[@"position",
-                                             @"anchorPoint"]];
+    positionKeyPaths = [NSSet setWithArray:@[@"position", @"anchorPoint"]];
   });
 
   if ([animation.toValue isKindOfClass:[NSNumber class]]) {
-    CGFloat currentValue = (CGFloat)[animation.fromValue doubleValue];
-    CGFloat delta = currentValue - (CGFloat)[animation.toValue doubleValue];
-    animation.fromValue = @(delta);
-    animation.toValue = @0;
-    animation.additive = true;
+    // Non-additive animations animate along a direct path between fromValue and toValue, regardless
+    // of the model layer. Additive animations, on the other hand, animate towards the layer's model
+    // value by applying this formula:
+    //
+    //     presentationLayer.value = modelLayer.value + additiveAnim1.value ... additiveAnimN.value
+    //
+    // This formula is what allows additive animations to give the appearance of conservation of
+    // momentum when multiple additive animations are added to the same key path.
+    //
+    // To transform a non-additive animation into an additive animation, use the following formula:
+    //
+    //     additiveAnimation.from = -(animation.to - animation.from)
+    //     additiveAnimation.to   = 0
+    //
+    // For example, if we're animating from 50 to 100, our additive animation's from value will
+    // equal -(100 - 50) = -50. Because the accumulator is animating to 0 and our model layer is
+    // set to the destination value, our animation will give the appearance of animating from 50 to
+    // 100:
+    //
+    //  | model value | accumulator | presentation value |
+    //  |-------------|-------------|--------------------|
+    //  |         100 |         -50 |                 50 |
+    //  |         100 |         -25 |                 75 |
+    //  |         100 |         -10 |                 90 |
+    //  |         100 |          -5 |                 95 |
+    //  |         100 |           0 |                100 |
+    //
+    //
+    CGFloat from = (CGFloat)[animation.fromValue doubleValue];
+    CGFloat to = (CGFloat)[animation.toValue doubleValue];
+    CGFloat displacement = to - from;
+    CGFloat additiveDisplacement = -displacement;
+
+    if (wantsAdditive) {
+      animation.fromValue = @(additiveDisplacement);
+      animation.toValue = @0;
+      animation.additive = true;
+    }
 
 #pragma clang diagnostic push
     // CASpringAnimation is a private API on iOS 8 - we're able to make use of it because we're
@@ -87,26 +125,59 @@ void MDMMakeAnimationAdditive(CABasicAnimation *animation) {
     if ([animation isKindOfClass:[CASpringAnimation class]]) {
       CASpringAnimation *springAnimation = (CASpringAnimation *)animation;
 #pragma clang diagnostic pop
-      // We expect initialVelocity to originally be in absolute coordinate space, so here we convert
-      // it to Core Animation's normalized coordinate space.
-      springAnimation.initialVelocity = springAnimation.initialVelocity / -delta;
+
+      CGFloat absoluteInitialVelocity = timing.curve.data[MDMSpringMotionCurveDataIndexInitialVelocity];
+
+      // Our timing's initialVelocity is in points per second, but Core Animation expects initial
+      // velocity to be in terms of displacement per second.
+      //
+      // From the UIView animateWithDuration header docs:
+      //
+      // "[initialVelocity is] a unit coordinate system, where 1 is defined as traveling the total
+      //  animation distance in a second. So if you're changing an object's position by 200pt in
+      //  this animation, and you want the animation to behave as if the object was moving at
+      //  100pt/s before the animation started, you'd pass 0.5. You'll typically want to pass 0 for
+      //  the velocity."
+      //
+      // It's also important to know that an initial velocity > 0 indicates movement towards the
+      // destination, while an initial velocity < 0 indicates movement away from the destination.
+      //
+      // With this in mind, consider Core Animation's initialVelocity as having two bits of
+      // information:
+      //
+      // - Its sign. Positive is towards the destination. Negative is away.
+      // - Its amplitude, where amplitude * displacement = absolute initial velocity
+      //
+      // For example: If our initialVelocity is +200/s, and our displacement is -100, then our
+      // initialVelocity is -2, with the (-) indicating that we're moving away from the destination
+      // and the 2 indicating we're moving twice the displacement over a second. Similarly, if our
+      // initialVelocity is -200/s, and our displacement is still -100 points, then our
+      // initialVelocity is 2; only the sign has changed.
+      //
+      // We want to know amplitude, so we do some basic arithmetic to turn:
+      //     amplitude * displacement = absolute initial velocity
+      // into:
+      //     amplitude = absolute initial velocity / displacement
+      //
+      // As for our sign, if absoluteInitialVelocity matches the direction of displacement, then our
+      // sign will be positive. Otherwise, our sign will be negative, as expected by Core Animation.
+
+      springAnimation.initialVelocity = absoluteInitialVelocity / displacement;
     }
 
   } else if ([sizeKeyPaths containsObject:animation.keyPath]) {
-    CGSize currentValue = [animation.fromValue CGSizeValue];
-    CGSize destinationValue = [animation.toValue CGSizeValue];
-    CGSize delta = CGSizeMake(currentValue.width - destinationValue.width,
-                              currentValue.height - destinationValue.height);
-    animation.fromValue = [NSValue valueWithCGSize:delta];
+    CGSize from = [animation.fromValue CGSizeValue];
+    CGSize to = [animation.toValue CGSizeValue];
+    CGSize additiveDisplacement = CGSizeMake(from.width - to.width, from.height - to.height);
+    animation.fromValue = [NSValue valueWithCGSize:additiveDisplacement];
     animation.toValue = [NSValue valueWithCGSize:CGSizeZero];
     animation.additive = true;
 
   } else if ([positionKeyPaths containsObject:animation.keyPath]) {
-    CGPoint currentValue = [animation.fromValue CGPointValue];
-    CGPoint destinationValue = [animation.toValue CGPointValue];
-    CGPoint delta = CGPointMake(currentValue.x - destinationValue.x,
-                                currentValue.y - destinationValue.y);
-    animation.fromValue = [NSValue valueWithCGPoint:delta];
+    CGPoint from = [animation.fromValue CGPointValue];
+    CGPoint to = [animation.toValue CGPointValue];
+    CGPoint additiveDisplacement = CGPointMake(from.x - to.x, from.y - to.y);
+    animation.fromValue = [NSValue valueWithCGPoint:additiveDisplacement];
     animation.toValue = [NSValue valueWithCGPoint:CGPointZero];
     animation.additive = true;
 
@@ -120,12 +191,13 @@ void MDMMakeAnimationAdditive(CABasicAnimation *animation) {
       // Core Animation's velocity system is single dimensional, so we pick the dominant direction
       // of movement and normalize accordingly.
       CGFloat biggestDelta;
-      if (fabs(delta.x) > fabs(delta.y)) {
-        biggestDelta = delta.x;
+      if (fabs(additiveDisplacement.x) > fabs(additiveDisplacement.y)) {
+        biggestDelta = additiveDisplacement.x;
       } else {
-        biggestDelta = delta.y;
+        biggestDelta = additiveDisplacement.y;
       }
-      springAnimation.initialVelocity = springAnimation.initialVelocity / -biggestDelta;
+      CGFloat displacement = -biggestDelta;
+      springAnimation.initialVelocity = springAnimation.initialVelocity / displacement;
     }
   }
 }

--- a/tests/unit/InitialVelocityTests.swift
+++ b/tests/unit/InitialVelocityTests.swift
@@ -1,0 +1,114 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MotionAnimator
+
+@available(iOS 9.0, *)
+class InitialVelocityTests: XCTestCase {
+
+  var animator: MotionAnimator!
+  var addedAnimations: [CAAnimation]!
+  override func setUp() {
+    super.setUp()
+
+    animator = MotionAnimator()
+    addedAnimations = []
+    animator.addCoreAnimationTracer { (_, animation) in
+      self.addedAnimations.append(animation)
+    }
+  }
+
+  override func tearDown() {
+    animator = nil
+    addedAnimations = nil
+
+    super.tearDown()
+  }
+
+  func testVelocityAmplitudeMatchesDisplacementWithPositiveDisplacement() {
+    let timing = MotionTiming(delay: 0,
+                              duration: 0.7,
+                              curve: .init(type: .spring, data: (1, 1, 1, 50)),
+                              repetition: .init(type: .none, amount: 0, autoreverses: false))
+    animator.animate(with: timing, to: CALayer(), withValues: [0, 100], keyPath: .opacity)
+
+    XCTAssertEqual(addedAnimations.count, 1)
+    let animation = addedAnimations.first as! CASpringAnimation
+    XCTAssertEqual(animation.initialVelocity, 0.5)
+  }
+
+  func testVelocityAmplitudeMatchesDisplacementWithNegativeDisplacement() {
+    let timing = MotionTiming(delay: 0,
+                              duration: 0.7,
+                              curve: .init(type: .spring, data: (1, 1, 1, -50)),
+                              repetition: .init(type: .none, amount: 0, autoreverses: false))
+    animator.animate(with: timing, to: CALayer(), withValues: [100, 0], keyPath: .opacity)
+
+    XCTAssertEqual(addedAnimations.count, 1)
+    let animation = addedAnimations.first as! CASpringAnimation
+    XCTAssertEqual(animation.initialVelocity, 0.5)
+  }
+
+  func testVelocityTowardsDestinationIsPositiveWithPositiveDisplacement() {
+    let timing = MotionTiming(delay: 0,
+                          duration: 0.7,
+                          curve: .init(type: .spring, data: (1, 1, 1, 100)),
+                          repetition: .init(type: .none, amount: 0, autoreverses: false))
+    animator.animate(with: timing, to: CALayer(), withValues: [0, 100], keyPath: .opacity)
+
+    XCTAssertEqual(addedAnimations.count, 1)
+    let animation = addedAnimations.first as! CASpringAnimation
+    XCTAssertGreaterThan(animation.initialVelocity, 0)
+  }
+
+  func testVelocityAwayFromDestinationIsNegativeWithPositiveDisplacement() {
+    let timing = MotionTiming(delay: 0,
+                              duration: 0.7,
+                              curve: .init(type: .spring, data: (1, 1, 1, -100)),
+                              repetition: .init(type: .none, amount: 0, autoreverses: false))
+    animator.animate(with: timing, to: CALayer(), withValues: [0, 100], keyPath: .opacity)
+
+    XCTAssertEqual(addedAnimations.count, 1)
+    let animation = addedAnimations.first as! CASpringAnimation
+    XCTAssertLessThan(animation.initialVelocity, 0)
+  }
+
+  func testVelocityTowardsDestinationIsPositiveWithNegativeDisplacement() {
+    let timing = MotionTiming(delay: 0,
+                              duration: 0.7,
+                              curve: .init(type: .spring, data: (1, 1, 1, -100)),
+                              repetition: .init(type: .none, amount: 0, autoreverses: false))
+    animator.animate(with: timing, to: CALayer(), withValues: [100, 0], keyPath: .opacity)
+
+    XCTAssertEqual(addedAnimations.count, 1)
+    let animation = addedAnimations.first as! CASpringAnimation
+    XCTAssertGreaterThan(animation.initialVelocity, 0)
+  }
+
+  func testVelocityAwayFromDestinationIsNegativeWithNegativeDisplacement() {
+    let timing = MotionTiming(delay: 0,
+                              duration: 0.7,
+                              curve: .init(type: .spring, data: (1, 1, 1, 100)),
+                              repetition: .init(type: .none, amount: 0, autoreverses: false))
+    animator.animate(with: timing, to: CALayer(), withValues: [100, 0], keyPath: .opacity)
+
+    XCTAssertEqual(addedAnimations.count, 1)
+    let animation = addedAnimations.first as! CASpringAnimation
+    XCTAssertLessThan(animation.initialVelocity, 0)
+  }
+}
+

--- a/tests/unit/InitialVelocityTests.swift
+++ b/tests/unit/InitialVelocityTests.swift
@@ -15,7 +15,11 @@
  */
 
 import XCTest
+#if IS_BAZEL_BUILD
+import _MotionAnimator
+#else
 import MotionAnimator
+#endif
 
 @available(iOS 9.0, *)
 class InitialVelocityTests: XCTestCase {


### PR DESCRIPTION
[v1.3.0](https://github.com/material-motion/motion-interchange-objc/releases/tag/v1.3.0) of the MotionInterchange documented a new data parameter for spring curves: initial velocity.

With this change we now extract initial velocity from the data object and apply it to spring animations. Also added tests.