### PR TITLE
Add support for removing added animations

### DIFF
--- a/examples/apps/Catalog/MotionAnimatorCatalog.xcodeproj/project.pbxproj
+++ b/examples/apps/Catalog/MotionAnimatorCatalog.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		667A3F4C1DEE269400CB3A99 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 667A3F4A1DEE269400CB3A99 /* LaunchScreen.storyboard */; };
 		667A3F541DEE273000CB3A99 /* TableOfContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 667A3F531DEE273000CB3A99 /* TableOfContents.swift */; };
 		6687264A1EF04B4C00113675 /* MotionAnimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668726491EF04B4C00113675 /* MotionAnimatorTests.swift */; };
+		66A6A6681FBA158000DE54CB /* AnimationRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66A6A6671FBA158000DE54CB /* AnimationRemovalTests.swift */; };
 		66BF5A8F1FB0E4CB00E864F6 /* ImplicitAnimationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66BF5A8E1FB0E4CB00E864F6 /* ImplicitAnimationTests.swift */; };
 		66DD4BF51EEF0ECB00207119 /* CalendarCardExpansionExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 66DD4BF41EEF0ECB00207119 /* CalendarCardExpansionExample.m */; };
 		66DD4BF81EEF1C4B00207119 /* CalendarChipMotionSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 66DD4BF71EEF1C4B00207119 /* CalendarChipMotionSpec.m */; };
@@ -62,6 +63,7 @@
 		667A3F4D1DEE269400CB3A99 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		667A3F531DEE273000CB3A99 /* TableOfContents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableOfContents.swift; sourceTree = "<group>"; };
 		668726491EF04B4C00113675 /* MotionAnimatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionAnimatorTests.swift; sourceTree = "<group>"; };
+		66A6A6671FBA158000DE54CB /* AnimationRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationRemovalTests.swift; sourceTree = "<group>"; };
 		66BF5A8E1FB0E4CB00E864F6 /* ImplicitAnimationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitAnimationTests.swift; sourceTree = "<group>"; };
 		66DD4BF31EEF0ECB00207119 /* CalendarCardExpansionExample.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CalendarCardExpansionExample.h; sourceTree = "<group>"; };
 		66DD4BF41EEF0ECB00207119 /* CalendarCardExpansionExample.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CalendarCardExpansionExample.m; sourceTree = "<group>"; };
@@ -208,6 +210,7 @@
 		66FD99F81EE9FBA000C53A82 /* unit */ = {
 			isa = PBXGroup;
 			children = (
+				66A6A6671FBA158000DE54CB /* AnimationRemovalTests.swift */,
 				66FD99F91EE9FBBE00C53A82 /* MotionAnimatorTests.m */,
 				668726491EF04B4C00113675 /* MotionAnimatorTests.swift */,
 				66BF5A8E1FB0E4CB00E864F6 /* ImplicitAnimationTests.swift */,
@@ -491,6 +494,7 @@
 				6625876C1FB4DB9C00BC7DF1 /* InitialVelocityTests.swift in Sources */,
 				660636021FACC24300C3DFB8 /* TimeScaleFactorTests.swift in Sources */,
 				66BF5A8F1FB0E4CB00E864F6 /* ImplicitAnimationTests.swift in Sources */,
+				66A6A6681FBA158000DE54CB /* AnimationRemovalTests.swift in Sources */,
 				6687264A1EF04B4C00113675 /* MotionAnimatorTests.swift in Sources */,
 				66FD99FA1EE9FBBE00C53A82 /* MotionAnimatorTests.m in Sources */,
 			);

--- a/src/MDMMotionAnimator.h
+++ b/src/MDMMotionAnimator.h
@@ -132,4 +132,21 @@ NS_SWIFT_NAME(MotionAnimator)
                animations:(nonnull void (^)(void))animations
                completion:(nullable void(^)(void))completion;
 
+/**
+ Removes every animation added by this animator.
+
+ Removing animations in this manner will give the appearance of each animated layer property
+ instantaneously jumping to its animated destination.
+ */
+- (void)removeAllAnimations;
+
+/**
+ Commits each added animation's current value to its associated layer and then removes every
+ animation added by this animator.
+
+ This method is most commonly called in reaction to the initiation of a gesture so that any
+ in-flight animations are stopped at their current on-screen position.
+ */
+- (void)commitAndRemoveAllAnimations;
+
 @end

--- a/src/MDMMotionAnimator.h
+++ b/src/MDMMotionAnimator.h
@@ -141,8 +141,8 @@ NS_SWIFT_NAME(MotionAnimator)
 - (void)removeAllAnimations;
 
 /**
- Commits each added animation's current value to its associated layer and then removes every
- animation added by this animator.
+ Commits the presentation layer to the model layer for every active animation and then removes
+ every animation.
 
  This method is most commonly called in reaction to the initiation of a gesture so that any
  in-flight animations are stopped at their current on-screen position.

--- a/src/MDMMotionAnimator.h
+++ b/src/MDMMotionAnimator.h
@@ -141,8 +141,8 @@ NS_SWIFT_NAME(MotionAnimator)
 - (void)removeAllAnimations;
 
 /**
- Commits the presentation layer to the model layer for every active animation and then removes
- every animation.
+ Commits the presentation layer value to the model layer value for every active animation's key path
+ and then removes every animation.
 
  This method is most commonly called in reaction to the initiation of a gesture so that any
  in-flight animations are stopped at their current on-screen position.

--- a/src/MDMMotionAnimator.h
+++ b/src/MDMMotionAnimator.h
@@ -147,6 +147,6 @@ NS_SWIFT_NAME(MotionAnimator)
  This method is most commonly called in reaction to the initiation of a gesture so that any
  in-flight animations are stopped at their current on-screen position.
  */
-- (void)commitAndRemoveAllAnimations;
+- (void)stopAllAnimations;
 
 @end

--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -44,11 +44,7 @@
                   toLayer:(CALayer *)layer
                withValues:(NSArray *)values
                   keyPath:(MDMAnimatableKeyPath)keyPath {
-  [self animateWithTiming:timing
-                  toLayer:layer
-               withValues:values
-                  keyPath:keyPath
-               completion:nil];
+  [self animateWithTiming:timing toLayer:layer withValues:values keyPath:keyPath completion:nil];
 }
 
 - (void)animateWithTiming:(MDMMotionTiming)timing

--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -161,7 +161,7 @@
   [_registrar removeAllAnimations];
 }
 
-- (void)commitAndRemoveAllAnimations {
+- (void)stopAllAnimations {
   [_registrar commitCurrentAnimationValuesToAllLayers];
   [_registrar removeAllAnimations];
 }

--- a/src/MotionAnimator.h
+++ b/src/MotionAnimator.h
@@ -17,3 +17,4 @@
 #import "CATransaction+MotionAnimator.h"
 #import "MDMAnimatableKeyPaths.h"
 #import "MDMMotionAnimator.h"
+

--- a/src/private/MDMAnimationRegistrar.h
+++ b/src/private/MDMAnimationRegistrar.h
@@ -14,6 +14,18 @@
  limitations under the License.
  */
 
-#import "CATransaction+MotionAnimator.h"
-#import "MDMAnimatableKeyPaths.h"
-#import "MDMMotionAnimator.h"
+#import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
+
+// Tracks animations that have been added to a layer.
+@interface MDMAnimationRegistrar : NSObject
+
+- (void)addAnimation:(CABasicAnimation *)animation
+             toLayer:(CALayer *)layer
+              forKey:(NSString *)key
+          completion:(void(^)(void))completion;
+
+- (void)commitCurrentAnimationValuesToAllLayers;
+- (void)removeAllAnimations;
+
+@end

--- a/src/private/MDMAnimationRegistrar.h
+++ b/src/private/MDMAnimationRegistrar.h
@@ -17,15 +17,22 @@
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
 
-// Tracks animations that have been added to a layer.
+// Tracks and manipulates animations that have been added to a layer.
 @interface MDMAnimationRegistrar : NSObject
 
-- (void)addAnimation:(CABasicAnimation *)animation
-             toLayer:(CALayer *)layer
-              forKey:(NSString *)key
-          completion:(void(^)(void))completion;
+// Invokes the layer's addAnimation:forKey: method with the provided animation and key and tracks
+// its association. Upon completion of the animation, the provided optional completion block will be
+// executed.
+- (void)addAnimation:(nonnull CABasicAnimation *)animation
+             toLayer:(nonnull CALayer *)layer
+              forKey:(nonnull NSString *)key
+          completion:(void(^ __nullable)(void))completion;
 
+// For every active animation, reads the associated layer's presentation layer key path and writes
+// it to the layer.
 - (void)commitCurrentAnimationValuesToAllLayers;
+
+// Removes all active animations from their associated layer.
 - (void)removeAllAnimations;
 
 @end

--- a/src/private/MDMAnimationRegistrar.m
+++ b/src/private/MDMAnimationRegistrar.m
@@ -19,7 +19,7 @@
 #import "MDMRegisteredAnimation.h"
 
 @implementation MDMAnimationRegistrar {
-  NSMapTable *_layersToRegisteredAnimation;
+  NSMapTable *_layersToRegisteredAnimation;  // Map of [CALayer:MDMRegisteredAnimation]
 }
 
 - (instancetype)init {

--- a/src/private/MDMAnimationRegistrar.m
+++ b/src/private/MDMAnimationRegistrar.m
@@ -19,7 +19,7 @@
 #import "MDMRegisteredAnimation.h"
 
 @implementation MDMAnimationRegistrar {
-  NSMapTable *_layersToRegisteredAnimation;  // Map of [CALayer:MDMRegisteredAnimation]
+  NSMapTable<CALayer *, NSMutableSet<MDMRegisteredAnimation *> *> *_layersToRegisteredAnimation;
 }
 
 - (instancetype)init {

--- a/src/private/MDMAnimationRegistrar.m
+++ b/src/private/MDMAnimationRegistrar.m
@@ -35,11 +35,11 @@
 
 - (void)forEachAnimation:(void (^)(CALayer *, CABasicAnimation *, NSString *))work {
   // Copy the registered animations before iteration in case further modifications happen to the
-  // registered animations.
-  NSMapTable *layersToRegisteredAnimation = [_layersToRegisteredAnimation copy];
-  for (CALayer *layer in layersToRegisteredAnimation) {
+  // registered animations. Consider if we remove an animation, its associated completion block
+  // might invoke logic that adds a new animation, potentially modifying our collections.
+  for (CALayer *layer in [_layersToRegisteredAnimation copy]) {
     NSSet *keyPathAnimations = [_layersToRegisteredAnimation objectForKey:layer];
-    for (MDMRegisteredAnimation *keyPathAnimation in keyPathAnimations) {
+    for (MDMRegisteredAnimation *keyPathAnimation in [keyPathAnimations copy]) {
       if (![keyPathAnimation.animation isKindOfClass:[CABasicAnimation class]]) {
         continue;
       }

--- a/src/private/MDMAnimationRegistrar.m
+++ b/src/private/MDMAnimationRegistrar.m
@@ -82,11 +82,6 @@
   [CATransaction commit];
 }
 
-- (void)animationDidCompleteOnLayer:(CALayer *)layer withKey:(NSString *)key {
-  NSMutableSet *animatedKeyPaths = [_layersToRegisteredAnimation objectForKey:layer];
-  [animatedKeyPaths removeObject:key];
-}
-
 - (void)commitCurrentAnimationValuesToAllLayers {
   [self forEachAnimation:^(CALayer *layer, CABasicAnimation *animation, NSString *key) {
     id presentationLayer = [layer presentationLayer];

--- a/src/private/MDMAnimationRegistrar.m
+++ b/src/private/MDMAnimationRegistrar.m
@@ -1,0 +1,121 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDMAnimationRegistrar.h"
+
+#import "MDMRegisteredAnimation.h"
+
+@implementation MDMAnimationRegistrar {
+  NSMapTable *_layersToRegisteredAnimation;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _layersToRegisteredAnimation = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsWeakMemory
+                                                      valueOptions:NSPointerFunctionsStrongMemory];
+  }
+  return self;
+}
+
+- (void)addAnimation:(CABasicAnimation *)animation
+                toLayer:(CALayer *)layer
+                 forKey:(NSString *)key
+             completion:(void(^)(void))completion {
+  if (key == nil) {
+    key = [NSUUID UUID].UUIDString;
+  }
+
+  NSMutableSet *animatedKeyPaths = [_layersToRegisteredAnimation objectForKey:layer];
+  if (!animatedKeyPaths) {
+    animatedKeyPaths = [[NSMutableSet alloc] init];
+    [_layersToRegisteredAnimation setObject:animatedKeyPaths forKey:layer];
+  }
+  MDMRegisteredAnimation *keyPathAnimation =
+      [[MDMRegisteredAnimation alloc] initWithKey:key animation:animation];
+  [animatedKeyPaths addObject:keyPathAnimation];
+
+  [CATransaction begin];
+  [CATransaction setCompletionBlock:^{
+    [animatedKeyPaths removeObject:keyPathAnimation];
+
+    if (completion) {
+      completion();
+    }
+  }];
+
+  [layer addAnimation:animation forKey:key];
+
+  [CATransaction commit];
+}
+
+- (void)forEveryAnimatedKey:(void (^)(CALayer *, CABasicAnimation *, NSString *))work {
+  for (CALayer *layer in _layersToRegisteredAnimation) {
+    NSSet *keyPathAnimations = [_layersToRegisteredAnimation objectForKey:layer];
+    for (MDMRegisteredAnimation *keyPathAnimation in keyPathAnimations) {
+      if (![keyPathAnimation.animation isKindOfClass:[CABasicAnimation class]]) {
+        continue;
+      }
+
+      work(layer, [keyPathAnimation.animation copy], keyPathAnimation.key);
+    }
+  }
+}
+
+- (void)forEveryAnimatedKeyOnLayer:(CALayer *)layer
+                                do:(void (^)(CALayer *, CABasicAnimation *, NSString *))work {
+  NSSet *keyPathAnimations = [_layersToRegisteredAnimation objectForKey:layer];
+  for (MDMRegisteredAnimation *keyPathAnimation in keyPathAnimations) {
+    if (![keyPathAnimation.animation isKindOfClass:[CABasicAnimation class]]) {
+      continue;
+    }
+
+    work(layer, [keyPathAnimation.animation copy], keyPathAnimation.key);
+  }
+}
+
+- (void)removeAllAnimationsFromLayer:(CALayer *)layer withKeys:(NSSet *)keys {
+  NSMutableSet *animatedKeyPaths = [_layersToRegisteredAnimation objectForKey:layer];
+  for (NSString *key in keys) {
+    [layer removeAnimationForKey:key];
+
+    [animatedKeyPaths removeObject:key];
+  }
+}
+
+- (void)animationDidCompleteOnLayer:(CALayer *)layer withKey:(NSString *)key {
+  NSMutableSet *animatedKeyPaths = [_layersToRegisteredAnimation objectForKey:layer];
+  [animatedKeyPaths removeObject:key];
+}
+
+- (void)commitCurrentAnimationValuesToAllLayers {
+  [self forEveryAnimatedKey:^(CALayer *layer, CABasicAnimation *animation, NSString *key) {
+    id presentationLayer = [layer presentationLayer];
+    if (presentationLayer != nil) {
+      id presentationValue = [presentationLayer valueForKeyPath:animation.keyPath];
+      [layer setValue:presentationValue forKeyPath:animation.keyPath];
+    }
+  }];
+}
+
+- (void)removeAllAnimations {
+  [self forEveryAnimatedKey:^(CALayer *layer, CABasicAnimation *animation, NSString *key) {
+    [layer removeAnimationForKey:key];
+  }];
+  [_layersToRegisteredAnimation removeAllObjects];
+}
+
+@end

--- a/src/private/MDMRegisteredAnimation.h
+++ b/src/private/MDMRegisteredAnimation.h
@@ -14,6 +14,15 @@
  limitations under the License.
  */
 
-#import "CATransaction+MotionAnimator.h"
-#import "MDMAnimatableKeyPaths.h"
-#import "MDMMotionAnimator.h"
+#import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
+
+@interface MDMRegisteredAnimation : NSObject
+
+- (instancetype)initWithKey:(NSString *)key animation:(CABasicAnimation *)animation;
+
+@property(nonatomic, copy, readonly) NSString *key;
+
+@property(nonatomic, strong, readonly) CABasicAnimation *animation;
+
+@end

--- a/src/private/MDMRegisteredAnimation.m
+++ b/src/private/MDMRegisteredAnimation.m
@@ -14,6 +14,26 @@
  limitations under the License.
  */
 
-#import "CATransaction+MotionAnimator.h"
-#import "MDMAnimatableKeyPaths.h"
-#import "MDMMotionAnimator.h"
+#import "MDMRegisteredAnimation.h"
+
+@implementation MDMRegisteredAnimation
+
+- (instancetype)initWithKey:(NSString *)key animation:(CABasicAnimation *)animation {
+  self = [super init];
+  if (self) {
+    _key = [key copy];
+    _animation = animation;
+  }
+  return self;
+}
+
+- (NSUInteger)hash {
+  return _key.hash;
+}
+
+- (BOOL)isEqual:(id)object {
+  return [_key isEqual:object];
+}
+
+@end
+

--- a/tests/unit/AnimationRemovalTests.swift
+++ b/tests/unit/AnimationRemovalTests.swift
@@ -82,7 +82,7 @@ class AnimationRemovalTests: XCTestCase {
     let result = XCTWaiter().wait(for: [didComplete], timeout: 0.01)
     XCTAssertEqual(result, .timedOut)
 
-    animator.commitAndRemoveAllAnimations()
+    animator.stopAllAnimations()
 
     XCTAssertNil(view.layer.animationKeys())
     XCTAssertEqual(view.layer.opacity, view.layer.presentation()?.opacity)

--- a/tests/unit/AnimationRemovalTests.swift
+++ b/tests/unit/AnimationRemovalTests.swift
@@ -1,0 +1,91 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+
+#if IS_BAZEL_BUILD
+import _MotionAnimator
+#else
+import MotionAnimator
+#endif
+
+class AnimationRemovalTests: XCTestCase {
+  var animator: MotionAnimator!
+  var timing: MotionTiming!
+  var view: UIView!
+
+  var originalImplementation: IMP?
+  override func setUp() {
+    super.setUp()
+
+    animator = MotionAnimator()
+    timing = MotionTiming(delay: 0,
+                          duration: 1,
+                          curve: MotionCurveMakeBezier(p1x: 0, p1y: 0, p2x: 0, p2y: 0),
+                          repetition: .init(type: .none, amount: 0, autoreverses: false))
+
+    let window = UIWindow()
+    window.makeKeyAndVisible()
+    view = UIView() // Need to animate a view's layer to get implicit animations.
+    window.addSubview(view)
+  }
+
+  override func tearDown() {
+    animator = nil
+    timing = nil
+    view = nil
+
+    super.tearDown()
+  }
+
+  func testAllAdditiveAnimationsGetsRemoved() {
+    animator.animate(with: timing, to: view.layer, withValues: [1, 0], keyPath: .opacity)
+    animator.animate(with: timing, to: view.layer, withValues: [0, 0.5], keyPath: .opacity)
+
+    XCTAssertEqual(view.layer.animationKeys()!.count, 2)
+
+    animator.removeAllAnimations()
+
+    XCTAssertNil(view.layer.animationKeys())
+    XCTAssertEqual(view.layer.opacity, 0.5)
+  }
+
+#if swift(>=3.2)
+  func testCommitAndRemoveAllAnimationsCommitsThePresentationValue() {
+    let didComplete = expectation(description: "Did complete")
+
+    CATransaction.begin()
+    CATransaction.setCompletionBlock {
+      didComplete.fulfill()
+    }
+
+    animator.animate(with: timing, to: view.layer, withValues: [1, 0], keyPath: .opacity)
+    animator.animate(with: timing, to: view.layer, withValues: [0, 0.5], keyPath: .opacity)
+
+    CATransaction.commit()
+
+    XCTAssertEqual(view.layer.animationKeys()!.count, 2)
+
+    let result = XCTWaiter().wait(for: [didComplete], timeout: 0.01)
+    XCTAssertEqual(result, .timedOut)
+
+    animator.commitAndRemoveAllAnimations()
+
+    XCTAssertNil(view.layer.animationKeys())
+    XCTAssertEqual(view.layer.opacity, view.layer.presentation()?.opacity)
+  }
+#endif
+}

--- a/tests/unit/AnimationRemovalTests.swift
+++ b/tests/unit/AnimationRemovalTests.swift
@@ -63,13 +63,11 @@ class AnimationRemovalTests: XCTestCase {
     XCTAssertEqual(view.layer.opacity, 0.5)
   }
 
-#if swift(>=3.2)
   func testCommitAndRemoveAllAnimationsCommitsThePresentationValue() {
-    let didComplete = expectation(description: "Did complete")
-
+    var didComplete = false
     CATransaction.begin()
     CATransaction.setCompletionBlock {
-      didComplete.fulfill()
+      didComplete = true
     }
 
     animator.animate(with: timing, to: view.layer, withValues: [1, 0], keyPath: .opacity)
@@ -79,13 +77,13 @@ class AnimationRemovalTests: XCTestCase {
 
     XCTAssertEqual(view.layer.animationKeys()!.count, 2)
 
-    let result = XCTWaiter().wait(for: [didComplete], timeout: 0.01)
-    XCTAssertEqual(result, .timedOut)
+    RunLoop.main.run(until: .init(timeIntervalSinceNow: 0.01))
+
+    XCTAssertFalse(didComplete)
 
     animator.stopAllAnimations()
 
     XCTAssertNil(view.layer.animationKeys())
     XCTAssertEqual(view.layer.opacity, view.layer.presentation()?.opacity)
   }
-#endif
 }


### PR DESCRIPTION
This change introduces two new APIs:

1. `removeAllAnimations`
2. `stopAllAnimations`

The difference between the two APIs is that one simply removes the animations, while the other commits the presentation layer value to the model layer value before removing the animation. The latter is primarily intended for use when implementing motion with gesture recognition.