### PR TITLE
Improved robustness of implicit animation support

### DIFF
--- a/src/MDMMotionAnimator.h
+++ b/src/MDMMotionAnimator.h
@@ -160,6 +160,7 @@ NS_SWIFT_NAME(MotionAnimator)
  be able to implicitly animate its properties with MDMMotionAnimator. This is not necessary for
  layers that are backing a UIView.
  */
-+ (nonnull id<CALayerDelegate>)sharedLayerDelegate;
++ (nonnull id<CALayerDelegate>)sharedLayerDelegate
+    __deprecated_msg("No longer needed for implicit animations of headless layers.");
 
 @end

--- a/src/private/MDMBlockAnimations.m
+++ b/src/private/MDMBlockAnimations.m
@@ -75,7 +75,7 @@ static NSMutableArray<MDMActionContext *> *sActionContext = nil;
 @interface MDMLayerDelegate: NSObject <CALayerDelegate>
 @end
 
-static id<CAAction> ActionForKey(CALayer *self, SEL _cmd, NSString *event) {
+static id<CAAction> ActionForKey(CALayer *layer, SEL _cmd, NSString *event) {
   NSCAssert([NSStringFromSelector(_cmd) isEqualToString:
                 NSStringFromSelector(@selector(actionForKey:))],
             @"Invalid method signature.");
@@ -87,15 +87,15 @@ static id<CAAction> ActionForKey(CALayer *self, SEL _cmd, NSString *event) {
     // Graceful handling of invalid state on non-debug builds for if our context is nil invokes our
     // original implementation:
     return ((id<CAAction>(*)(id, SEL, NSString *))sOriginalActionForKeyLayerImp)
-              (self, _cmd, event);
+              (layer, _cmd, event);
   }
 
   // We don't have access to the "to" value of our animation here, so we unfortunately can't
   // calculate additive values if the animator is configured as such. So, to support additive
   // animations, we queue up the modified actions and then add them all at the end of our
   // MDMAnimateImplicitly invocation.
-  id initialValue = [self valueForKeyPath:event];
-  [context addActionForLayer:self keyPath:event withInitialValue:initialValue];
+  id initialValue = [layer valueForKeyPath:event];
+  [context addActionForLayer:layer keyPath:event withInitialValue:initialValue];
   return [NSNull null];
 }
 

--- a/tests/unit/ImplicitAnimationTests.swift
+++ b/tests/unit/ImplicitAnimationTests.swift
@@ -53,12 +53,12 @@ class ImplicitAnimationTests: XCTestCase {
     CATransaction.flush()
 
     originalImplementation =
-      class_getMethodImplementation(UIView.self, #selector(UIView.action(for:forKey:)))
+      class_getMethodImplementation(CALayer.self, #selector(CALayer.action(forKey:)))
   }
 
   override func tearDown() {
     let implementation =
-        class_getMethodImplementation(UIView.self, #selector(UIView.action(for:forKey:)))
+        class_getMethodImplementation(CALayer.self, #selector(CALayer.action(forKey:)))
     XCTAssertEqual(originalImplementation, implementation)
 
     animator = nil


### PR DESCRIPTION
When animating implicitly with the motion animator we now swizzle the CALayer actionForKey: implementation rather than UIView's equivalent API. This means that we don't need to set a delegate on the layer in order to receive queries for implicit animation actions.

Prior to this change we were swizzling step 1 of the following action query algorithm (as documented in CALayer):

1. if defined, call the delegate method -actionForLayer:forKey:
2. look in the layer's `actions' dictionary
3. look in any `actions' dictionaries in the `style' hierarchy
4. call +defaultActionForKey: on the layer's class

This unfortunately depended on there being a delegate assigned to the layer. To support headless CALayers we introduced the `+sharedLayerDelegate` API so that such a delegate could be provided.

With this change, we now swizzle the entire algorithm instead, effectively injecting a new step before step 1. This also removes the need to support `+sharedLayerDelegate`. As such, `+sharedLayerDelegate` is now deprecated because it is no longer needed.

Closes https://github.com/material-motion/motion-animator-objc/issues/49