### PR TITLE
Always commit the model layer value inside a transaction with actions disabled.

### DIFF
--- a/examples/apps/Catalog/MotionAnimatorCatalog.xcodeproj/project.pbxproj
+++ b/examples/apps/Catalog/MotionAnimatorCatalog.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		66DD4BF51EEF0ECB00207119 /* CalendarCardExpansionExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 66DD4BF41EEF0ECB00207119 /* CalendarCardExpansionExample.m */; };
 		66DD4BF81EEF1C4B00207119 /* CalendarChipMotionSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 66DD4BF71EEF1C4B00207119 /* CalendarChipMotionSpec.m */; };
 		66EF6F281FC33C4800C83A63 /* HeadlessLayerImplicitAnimationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66EF6F271FC33C4800C83A63 /* HeadlessLayerImplicitAnimationTests.swift */; };
+		66EF6F2A1FC48D6A00C83A63 /* InstantAnimationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66EF6F291FC48D6A00C83A63 /* InstantAnimationTests.swift */; };
 		66FD99FA1EE9FBBE00C53A82 /* MotionAnimatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 66FD99F91EE9FBBE00C53A82 /* MotionAnimatorTests.m */; };
 		FCA09739CCE089F0D051AA87 /* Pods_MotionAnimatorCatalog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50D808A6F9E944D54276D32F /* Pods_MotionAnimatorCatalog.framework */; };
 /* End PBXBuildFile section */
@@ -71,6 +72,7 @@
 		66DD4BF61EEF1C4B00207119 /* CalendarChipMotionSpec.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CalendarChipMotionSpec.h; sourceTree = "<group>"; };
 		66DD4BF71EEF1C4B00207119 /* CalendarChipMotionSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CalendarChipMotionSpec.m; sourceTree = "<group>"; };
 		66EF6F271FC33C4800C83A63 /* HeadlessLayerImplicitAnimationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadlessLayerImplicitAnimationTests.swift; sourceTree = "<group>"; };
+		66EF6F291FC48D6A00C83A63 /* InstantAnimationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantAnimationTests.swift; sourceTree = "<group>"; };
 		66FD99F91EE9FBBE00C53A82 /* MotionAnimatorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MotionAnimatorTests.m; sourceTree = "<group>"; };
 		6EB4A3E0A8428C89A9BE95EE /* Pods-MotionAnimatorCatalog.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MotionAnimatorCatalog.release.xcconfig"; path = "../../../Pods/Target Support Files/Pods-MotionAnimatorCatalog/Pods-MotionAnimatorCatalog.release.xcconfig"; sourceTree = "<group>"; };
 		9DE90426033EDF40C65232A9 /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "../../../Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -214,10 +216,11 @@
 			children = (
 				66A6A6671FBA158000DE54CB /* AnimationRemovalTests.swift */,
 				66EF6F271FC33C4800C83A63 /* HeadlessLayerImplicitAnimationTests.swift */,
-				66FD99F91EE9FBBE00C53A82 /* MotionAnimatorTests.m */,
-				668726491EF04B4C00113675 /* MotionAnimatorTests.swift */,
 				66BF5A8E1FB0E4CB00E864F6 /* ImplicitAnimationTests.swift */,
 				6625876B1FB4DB9C00BC7DF1 /* InitialVelocityTests.swift */,
+				66EF6F291FC48D6A00C83A63 /* InstantAnimationTests.swift */,
+				66FD99F91EE9FBBE00C53A82 /* MotionAnimatorTests.m */,
+				668726491EF04B4C00113675 /* MotionAnimatorTests.swift */,
 				660636011FACC24300C3DFB8 /* TimeScaleFactorTests.swift */,
 			);
 			path = unit;
@@ -496,6 +499,7 @@
 			files = (
 				6625876C1FB4DB9C00BC7DF1 /* InitialVelocityTests.swift in Sources */,
 				66EF6F281FC33C4800C83A63 /* HeadlessLayerImplicitAnimationTests.swift in Sources */,
+				66EF6F2A1FC48D6A00C83A63 /* InstantAnimationTests.swift in Sources */,
 				660636021FACC24300C3DFB8 /* TimeScaleFactorTests.swift in Sources */,
 				66BF5A8F1FB0E4CB00E864F6 /* ImplicitAnimationTests.swift in Sources */,
 				66A6A6681FBA158000DE54CB /* AnimationRemovalTests.swift in Sources */,

--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -59,8 +59,12 @@
   }
   values = MDMCoerceUIKitValuesToCoreAnimationValues(values);
 
+  [CATransaction begin];
+  [CATransaction setDisableActions:YES];
+  [layer setValue:[values lastObject] forKeyPath:keyPath];
+  [CATransaction commit];
+
   if (timing.duration == 0 || timing.curve.type == MDMMotionCurveTypeInstant) {
-    [layer setValue:[values lastObject] forKeyPath:keyPath];
     if (completion) {
       completion();
     }
@@ -104,11 +108,6 @@
       }
     }
   }
-
-  [CATransaction begin];
-  [CATransaction setDisableActions:YES];
-  [layer setValue:[values lastObject] forKeyPath:keyPath];
-  [CATransaction commit];
 }
 
 - (void)animateWithTiming:(MDMMotionTiming)timing animations:(void (^)(void))animations {

--- a/tests/unit/InstantAnimationTests.swift
+++ b/tests/unit/InstantAnimationTests.swift
@@ -1,0 +1,78 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+#if IS_BAZEL_BUILD
+import _MotionAnimator
+#else
+import MotionAnimator
+#endif
+
+class InstantAnimationTests: XCTestCase {
+
+  var animator: MotionAnimator!
+  var timing: MotionTiming!
+  var view: UIView!
+  var addedAnimations: [CAAnimation]!
+
+  override func setUp() {
+    super.setUp()
+
+    animator = MotionAnimator()
+
+    timing = MotionTiming(delay: 0,
+                          duration: 0,
+                          curve: .init(type: .instant, data: (0, 0, 0, 0)),
+                          repetition: .init(type: .none, amount: 0, autoreverses: false))
+
+    let window = UIWindow()
+    window.makeKeyAndVisible()
+    view = UIView() // Need to animate a view's layer to get implicit animations.
+    window.addSubview(view)
+
+    addedAnimations = []
+    animator.addCoreAnimationTracer { (_, animation) in
+      self.addedAnimations.append(animation)
+    }
+  }
+
+  override func tearDown() {
+    animator = nil
+    view = nil
+    addedAnimations = nil
+
+    super.tearDown()
+  }
+
+  func testDoesNotGenerateImplicitAnimations() {
+    animator.animate(with: timing, to: view.layer, withValues: [1, 0.5], keyPath: .opacity)
+
+    XCTAssertNil(view.layer.animationKeys())
+    XCTAssertEqual(addedAnimations.count, 0)
+  }
+
+  func testDoesNotGenerateImplicitAnimationsInUIViewAnimationBlock() {
+    UIView.animate(withDuration: 0.5) {
+      self.animator.animate(with: self.timing,
+                            to: self.view.layer,
+                            withValues: [1, 0.5],
+                            keyPath: .opacity)
+    }
+
+    XCTAssertNil(view.layer.animationKeys())
+    XCTAssertEqual(addedAnimations.count, 0)
+  }
+}


### PR DESCRIPTION
If the timing's duration was 0 or the animation was instant we were setting the model layer value without disabling actions, which could potentially result in an animation occurring.

The proper model value setting logic has now been moved to the top of the animate method and the duplicate logic has been removed.