### PR TITLE
Flatten the animate internal logic.

### DIFF
--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -64,49 +64,54 @@
   [layer setValue:[values lastObject] forKeyPath:keyPath];
   [CATransaction commit];
 
-  if (timing.duration == 0 || timing.curve.type == MDMMotionCurveTypeInstant) {
+  void (^exitEarly)(void) = ^{
     if (completion) {
       completion();
     }
-    return;
-  }
+  };
 
   CGFloat timeScaleFactor = [self computedTimeScaleFactor];
   CABasicAnimation *animation = MDMAnimationFromTiming(timing, timeScaleFactor);
 
-  if (animation) {
-    animation.keyPath = keyPath;
+  if (animation == nil) {
+    exitEarly();
+    return;
+  }
 
-    id initialValue;
-    if (_beginFromCurrentState) {
-      if ([layer presentationLayer]) {
-        initialValue = [[layer presentationLayer] valueForKeyPath:keyPath];
-      } else {
-        initialValue = [layer valueForKeyPath:keyPath];
-      }
+  animation.keyPath = keyPath;
+
+  id initialValue;
+  if (_beginFromCurrentState) {
+    if ([layer presentationLayer]) {
+      initialValue = [[layer presentationLayer] valueForKeyPath:keyPath];
     } else {
-      initialValue = [values firstObject];
+      initialValue = [layer valueForKeyPath:keyPath];
     }
+  } else {
+    initialValue = [values firstObject];
+  }
 
-    animation.fromValue = initialValue;
-    animation.toValue = [values lastObject];
+  animation.fromValue = initialValue;
+  animation.toValue = [values lastObject];
 
-    if (![animation.fromValue isEqual:animation.toValue]) {
-      MDMConfigureAnimation(animation, self.additive, timing);
+  if ([animation.fromValue isEqual:animation.toValue]) {
+    exitEarly();
+    return;
+  }
 
-      if (timing.delay != 0) {
-        animation.beginTime = ([layer convertTime:CACurrentMediaTime() fromLayer:nil]
-                               + timing.delay * timeScaleFactor);
-        animation.fillMode = kCAFillModeBackwards;
-      }
+  MDMConfigureAnimation(animation, self.additive, timing);
 
-      NSString *key = _additive ? nil : keyPath;
-      [_registrar addAnimation:animation toLayer:layer forKey:key completion:completion];
+  if (timing.delay != 0) {
+    animation.beginTime = ([layer convertTime:CACurrentMediaTime() fromLayer:nil]
+                           + timing.delay * timeScaleFactor);
+    animation.fillMode = kCAFillModeBackwards;
+  }
 
-      for (void (^tracer)(CALayer *, CAAnimation *) in _tracers) {
-        tracer(layer, animation);
-      }
-    }
+  NSString *key = _additive ? nil : keyPath;
+  [_registrar addAnimation:animation toLayer:layer forKey:key completion:completion];
+
+  for (void (^tracer)(CALayer *, CAAnimation *) in _tracers) {
+    tracer(layer, animation);
   }
 }
 

--- a/src/private/CABasicAnimation+MotionAnimator.m
+++ b/src/private/CABasicAnimation+MotionAnimator.m
@@ -35,6 +35,10 @@ CABasicAnimation *MDMAnimationFromTiming(MDMMotionTiming timing, CGFloat timeSca
       animation = [CABasicAnimation animation];
       animation.timingFunction = MDMTimingFunctionWithControlPoints(timing.curve.data);
       animation.duration = timing.duration * timeScaleFactor;
+
+      if (animation.duration == 0) {
+        return nil;
+      }
       break;
 
     case MDMMotionCurveTypeSpring: {


### PR DESCRIPTION
The internal logic has been flattened to make use of early exiting logic rather than a nested conditional. This will allow us to pull the logic out into smaller methods in order to make the code more self-documenting.