### PR TITLE
Spring animations now take velocity into account when determining duration.

### DIFF
--- a/src/private/CABasicAnimation+MotionAnimator.m
+++ b/src/private/CABasicAnimation+MotionAnimator.m
@@ -47,13 +47,8 @@ CABasicAnimation *MDMAnimationFromTiming(MDMMotionTiming timing, CGFloat timeSca
       spring.mass = timing.curve.data[MDMSpringMotionCurveDataIndexMass];
       spring.stiffness = timing.curve.data[MDMSpringMotionCurveDataIndexTension];
       spring.damping = timing.curve.data[MDMSpringMotionCurveDataIndexFriction];
+      spring.duration = timing.duration;
 
-      // This API is only available on iOS 9+
-      if ([spring respondsToSelector:@selector(settlingDuration)]) {
-        spring.duration = spring.settlingDuration;
-      } else {
-        spring.duration = timing.duration;
-      }
       animation = spring;
       break;
     }
@@ -223,6 +218,19 @@ void MDMConfigureAnimation(CABasicAnimation *animation,
       CGFloat absoluteInitialVelocity =
           timing.curve.data[MDMSpringMotionCurveDataIndexInitialVelocity];
       springAnimation.initialVelocity = absoluteInitialVelocity / displacement;
+    }
+  }
+
+  // Update the animation's duration to match the proposed settling duration.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+  if ([animation isKindOfClass:[CASpringAnimation class]]) {
+    CASpringAnimation *springAnimation = (CASpringAnimation *)animation;
+#pragma clang diagnostic pop
+
+    // This API is only available on iOS 9+
+    if ([springAnimation respondsToSelector:@selector(settlingDuration)]) {
+      animation.duration = springAnimation.settlingDuration;
     }
   }
 }

--- a/tests/unit/InitialVelocityTests.swift
+++ b/tests/unit/InitialVelocityTests.swift
@@ -121,6 +121,19 @@ class InitialVelocityTests: XCTestCase {
     }
   }
 
+  func testVelocityInfluencesDuration() {
+    let velocity: CGFloat = 50
+    animate(from: 0, to: 100, withVelocity: velocity)
+
+    XCTAssertEqual(addedAnimations.count, 3)
+    addedAnimations.flatMap { $0 as? CASpringAnimation }.forEach { animation in
+      XCTAssertEqual(animation.duration, animation.settlingDuration,
+                     "from: \(animation.fromValue!), "
+                      + "to: \(animation.toValue!), "
+                      + "withVelocity: \(velocity)")
+    }
+  }
+
   private func animate(from: CGFloat, to: CGFloat, withVelocity velocity: CGFloat) {
     let timing = MotionTiming(delay: 0,
                               duration: 0.7,


### PR DESCRIPTION
Prior to this change, spring animations were calculating their settling time prior to having set their initial velocity.

After this change, spring animations will calculate their settling time after having set the initial velocity.