### PR TITLE
Allow headless CALayers to implicitly animate when using the sharedLayerDelegate.

### DIFF
--- a/src/private/MDMBlockAnimations.m
+++ b/src/private/MDMBlockAnimations.m
@@ -141,7 +141,7 @@ NSArray<MDMImplicitAction *> *MDMAnimateImplicitly(void (^work)(void)) {
 - (id<CAAction>)actionForLayer:(CALayer *)layer forKey:(NSString *)event {
   // Check whether we're inside of an MDMAnimateImplicitly block or not.
   if (sOriginalActionForLayerImp == nil) {
-    return [NSNull null];
+    return nil; // Tell Core Animation to Keep searching for an action provider.
   }
   return ActionForLayer(layer, _cmd, layer, event);
 }

--- a/tests/unit/AnimationRemovalTests.swift
+++ b/tests/unit/AnimationRemovalTests.swift
@@ -41,6 +41,9 @@ class AnimationRemovalTests: XCTestCase {
     window.makeKeyAndVisible()
     view = UIView() // Need to animate a view's layer to get implicit animations.
     window.addSubview(view)
+
+    // Connect our layers to the render server.
+    CATransaction.flush()
   }
 
   override func tearDown() {

--- a/tests/unit/HeadlessLayerImplicitAnimationTests.swift
+++ b/tests/unit/HeadlessLayerImplicitAnimationTests.swift
@@ -40,7 +40,7 @@ class HeadlessLayerImplicitAnimationTests: XCTestCase {
 
     window.layer.addSublayer(layer)
 
-    // Connect our layer to the render server.
+    // Connect our layers to the render server.
     CATransaction.flush()
   }
 

--- a/tests/unit/HeadlessLayerImplicitAnimationTests.swift
+++ b/tests/unit/HeadlessLayerImplicitAnimationTests.swift
@@ -28,43 +28,128 @@ import MotionAnimator
 // motion animator support.
 class HeadlessLayerImplicitAnimationTests: XCTestCase {
 
-  func testDoesNotImplicitlyAnimate() {
-    let layer = CALayer()
-    // No delegate = no implicit animations.
+  var window: UIWindow!
+  var layer: CALayer!
+  override func setUp() {
+    super.setUp()
 
+    window = UIWindow()
+    window.makeKeyAndVisible()
+
+    layer = CALayer()
+
+    window.layer.addSublayer(layer)
+
+    // Connect our layer to the render server.
+    CATransaction.flush()
+  }
+
+  override func tearDown() {
+    layer = nil
+    window = nil
+
+    super.tearDown()
+  }
+
+  func testDoesImplicitlyAnimateInCATransaction() {
+    CATransaction.begin()
+    CATransaction.setAnimationDuration(0.5)
+    layer.opacity = 0.5
+    CATransaction.commit()
+
+    XCTAssertEqual(layer.animationKeys()!, ["opacity"])
+  }
+
+  func testDoesNotImplicitlyAnimateInCATransactionWithActionsDisabled() {
+    CATransaction.begin()
+    CATransaction.setAnimationDuration(0.5)
+    CATransaction.setDisableActions(true)
+    layer.opacity = 0.5
+    CATransaction.commit()
+
+    XCTAssertNil(layer.animationKeys())
+  }
+
+  func testDoesImplicitlyAnimateInUIViewAnimateBlock() {
     UIView.animate(withDuration: 0.5) {
-      layer.opacity = 0.5
+      self.layer.opacity = 0.5
+    }
+
+    XCTAssertEqual(layer.animationKeys()!, ["opacity"])
+  }
+
+  func testDoesNotImplicitlyAnimateInUIViewAnimateBlockWithActionsDisabledInside() {
+    UIView.animate(withDuration: 0.5) {
+      CATransaction.begin()
+      CATransaction.setDisableActions(true)
+      self.layer.opacity = 0.5
+      CATransaction.commit()
     }
 
     XCTAssertNil(layer.animationKeys())
   }
 
-  func testDoesNotImplicitlyAnimateWithLayerDelegateAlone() {
-    let layer = CALayer()
+  func testDoesNotImplicitlyAnimateInUIViewAnimateBlockWithActionsDisabledOutside() {
+    CATransaction.begin()
+    CATransaction.setDisableActions(true)
+    UIView.animate(withDuration: 0.5) {
+      self.layer.opacity = 0.5
+    }
+    CATransaction.commit()
+
+    XCTAssertNil(layer.animationKeys())
+  }
+
+  func testDoesImplicitlyAnimateInCATransactionWithLayerDelegateAlone() {
+    // Delegate will allow us to do implicit animations, but only via the motion animator.
+    layer.delegate = MotionAnimator.sharedLayerDelegate()
+
+    CATransaction.begin()
+    CATransaction.setAnimationDuration(0.5)
+    layer.opacity = 0.5
+    CATransaction.commit()
+
+    XCTAssertEqual(layer.animationKeys()!, ["opacity"])
+  }
+
+  func testDoesNotImplicitlyAnimateInCATransactionWithLayerDelegateAloneAndActionsAreDisabled() {
+    // Delegate will allow us to do implicit animations, but only via the motion animator.
+    layer.delegate = MotionAnimator.sharedLayerDelegate()
+
+    CATransaction.begin()
+    CATransaction.setAnimationDuration(0.5)
+    CATransaction.setDisableActions(true)
+    layer.opacity = 0.5
+    CATransaction.commit()
+
+    XCTAssertNil(layer.animationKeys())
+  }
+
+  func testDoesImplicitlyAnimateInUIViewAnimateBlockWithLayerDelegateAlone() {
     // Delegate will allow us to do implicit animations, but only via the motion animator.
     layer.delegate = MotionAnimator.sharedLayerDelegate()
 
     UIView.animate(withDuration: 0.5) {
-      layer.opacity = 0.5
+      self.layer.opacity = 0.5
     }
 
-    XCTAssertNil(layer.animationKeys())
+    XCTAssertEqual(layer.animationKeys()!, ["opacity"])
   }
 
   func testDoesImplicitlyAnimateWithLayerDelegateAndAnimator() {
-    let layer = CALayer()
     layer.delegate = MotionAnimator.sharedLayerDelegate()
 
     let animator = MotionAnimator()
+    animator.additive = false
     let timing = MotionTiming(delay: 0,
                               duration: 1,
                               curve: MotionCurveMakeBezier(p1x: 0, p1y: 0, p2x: 0, p2y: 0),
                               repetition: .init(type: .none, amount: 0, autoreverses: false))
 
     animator.animate(with: timing) {
-      layer.opacity = 0.5
+      self.layer.opacity = 0.5
     }
 
-    XCTAssertEqual(layer.animationKeys()?.count, 1)
+    XCTAssertEqual(layer.animationKeys()!, ["opacity"])
   }
 }

--- a/tests/unit/HeadlessLayerImplicitAnimationTests.swift
+++ b/tests/unit/HeadlessLayerImplicitAnimationTests.swift
@@ -51,6 +51,16 @@ class HeadlessLayerImplicitAnimationTests: XCTestCase {
     super.tearDown()
   }
 
+  func testUnFlushedLayerDoesNotImplicitlyAnimateInCATransaction() {
+    let unflushedLayer = CALayer()
+    CATransaction.begin()
+    CATransaction.setAnimationDuration(0.5)
+    unflushedLayer.opacity = 0.5
+    CATransaction.commit()
+
+    XCTAssertNil(unflushedLayer.animationKeys())
+  }
+
   func testDoesImplicitlyAnimateInCATransaction() {
     CATransaction.begin()
     CATransaction.setAnimationDuration(0.5)

--- a/tests/unit/ImplicitAnimationTests.swift
+++ b/tests/unit/ImplicitAnimationTests.swift
@@ -187,4 +187,23 @@ class ImplicitAnimationTests: XCTestCase {
     XCTAssertEqual(addedAnimations.count, 0)
     XCTAssertEqual(view.alpha, 0)
   }
+
+  func testBackingLayerDoesNotImplicitlyAnimate() {
+    CATransaction.begin()
+    CATransaction.setAnimationDuration(0.5)
+
+    view.layer.opacity = 0.5
+
+    CATransaction.commit()
+
+    XCTAssertNil(view.layer.animationKeys())
+  }
+
+  func testBackingLayerDoesAnimateInsideUIViewAnimateBlock() {
+    UIView.animate(withDuration: 0.5) {
+      self.view.layer.opacity = 0.5
+    }
+
+    XCTAssertEqual(view.layer.animationKeys()!, ["opacity"])
+  }
 }

--- a/tests/unit/ImplicitAnimationTests.swift
+++ b/tests/unit/ImplicitAnimationTests.swift
@@ -49,6 +49,9 @@ class ImplicitAnimationTests: XCTestCase {
       self.addedAnimations.append(animation)
     }
 
+    // Connect our layers to the render server.
+    CATransaction.flush()
+
     originalImplementation =
       class_getMethodImplementation(UIView.self, #selector(UIView.action(for:forKey:)))
   }

--- a/tests/unit/InstantAnimationTests.swift
+++ b/tests/unit/InstantAnimationTests.swift
@@ -43,6 +43,9 @@ class InstantAnimationTests: XCTestCase {
     view = UIView() // Need to animate a view's layer to get implicit animations.
     window.addSubview(view)
 
+    // Connect our layers to the render server.
+    CATransaction.flush()
+
     addedAnimations = []
     animator.addCoreAnimationTracer { (_, animation) in
       self.addedAnimations.append(animation)


### PR DESCRIPTION
Returning `NSNull` from `-actionForLayer:forKey:`  tells Core Animation to stop searching for an action provider, essentially disabling the default CALayer implicit animation path.

Our shared layer delegate was returning NSNull prior to this change, meaning code like the following would not create implicit animations:

```swift
headlessLayer.delegate = MotionAnimator.sharedLayerDelegate()
CATransaction.begin()
CATransaction.setAnimationDuration(0.5)
headlessLayer.opacity = 0.5
CATransaction.commit()
```

Commenting out the delegate assignment would re-enable implicit animations:

```swift
//headlessLayer.delegate = MotionAnimator.sharedLayerDelegate()
CATransaction.begin()
CATransaction.setAnimationDuration(0.5)
headlessLayer.opacity = 0.5
CATransaction.commit()
```

When using MotionAnimator's `sharedLayerDelegate` we do not want to change any default behavior, so rather than return `NSNull` we now return `nil`. `nil` indicates to Core Animation that it should continue searching for an action provider. In the case of a headless CALayer, this allows `+defaultActionForKey` to be invoked.

----

On a related note, CALayer instances that have not yet been connected to the render server (due to a CATransaction being flushed) will not implicitly animate. In order to ensure that we're testing realistic code, we now flush the CATransaction before making modifications to the layers. This ensures that the expected implicit animation behavior occurs.