### PR TITLE
If timeScaleFactor is 0 then exit early.

### DIFF
--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -71,6 +71,11 @@
   };
 
   CGFloat timeScaleFactor = [self computedTimeScaleFactor];
+  if (timeScaleFactor == 0) {
+    exitEarly();
+    return;
+  }
+
   CABasicAnimation *animation = MDMAnimationFromTiming(timing, timeScaleFactor);
 
   if (animation == nil) {


### PR DESCRIPTION
No need to animate if the animations will be instant.