### PR TITLE
Add UIKit behavioral tests.

### DIFF
--- a/examples/apps/Catalog/MotionAnimatorCatalog.xcodeproj/project.pbxproj
+++ b/examples/apps/Catalog/MotionAnimatorCatalog.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2AA864EDA683CEF5FAA721BE /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2DBE814C7B88BAD6337052DB /* Pods_UnitTests.framework */; };
 		660636021FACC24300C3DFB8 /* TimeScaleFactorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660636011FACC24300C3DFB8 /* TimeScaleFactorTests.swift */; };
 		6625876C1FB4DB9C00BC7DF1 /* InitialVelocityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6625876B1FB4DB9C00BC7DF1 /* InitialVelocityTests.swift */; };
+		664F59941FCCE27E002EC56D /* UIKitBehavioralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664F59931FCCE27E002EC56D /* UIKitBehavioralTests.swift */; };
 		666FAA841D384A6B000363DA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666FAA831D384A6B000363DA /* AppDelegate.swift */; };
 		666FAA8B1D384A6B000363DA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 666FAA8A1D384A6B000363DA /* Assets.xcassets */; };
 		666FAA8E1D384A6B000363DA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 666FAA8C1D384A6B000363DA /* LaunchScreen.storyboard */; };
@@ -51,6 +52,7 @@
 		52820916F8FAA40E942A7333 /* Pods-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.release.xcconfig"; path = "../../../Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
 		660636011FACC24300C3DFB8 /* TimeScaleFactorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeScaleFactorTests.swift; sourceTree = "<group>"; };
 		6625876B1FB4DB9C00BC7DF1 /* InitialVelocityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialVelocityTests.swift; sourceTree = "<group>"; };
+		664F59931FCCE27E002EC56D /* UIKitBehavioralTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitBehavioralTests.swift; sourceTree = "<group>"; };
 		666FAA801D384A6B000363DA /* MotionAnimatorCatalog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MotionAnimatorCatalog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		666FAA831D384A6B000363DA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Catalog/AppDelegate.swift; sourceTree = "<group>"; };
 		666FAA8A1D384A6B000363DA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 				66FD99F91EE9FBBE00C53A82 /* MotionAnimatorTests.m */,
 				668726491EF04B4C00113675 /* MotionAnimatorTests.swift */,
 				660636011FACC24300C3DFB8 /* TimeScaleFactorTests.swift */,
+				664F59931FCCE27E002EC56D /* UIKitBehavioralTests.swift */,
 			);
 			path = unit;
 			sourceTree = "<group>";
@@ -499,6 +502,7 @@
 			files = (
 				6625876C1FB4DB9C00BC7DF1 /* InitialVelocityTests.swift in Sources */,
 				66EF6F281FC33C4800C83A63 /* HeadlessLayerImplicitAnimationTests.swift in Sources */,
+				664F59941FCCE27E002EC56D /* UIKitBehavioralTests.swift in Sources */,
 				66EF6F2A1FC48D6A00C83A63 /* InstantAnimationTests.swift in Sources */,
 				660636021FACC24300C3DFB8 /* TimeScaleFactorTests.swift in Sources */,
 				66BF5A8F1FB0E4CB00E864F6 /* ImplicitAnimationTests.swift in Sources */,

--- a/tests/unit/UIKitBehavioralTests.swift
+++ b/tests/unit/UIKitBehavioralTests.swift
@@ -1,0 +1,141 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+#if IS_BAZEL_BUILD
+import _MotionAnimator
+#else
+import MotionAnimator
+#endif
+
+class ShapeLayerBackedView: UIView {
+  override static var layerClass: AnyClass { return CAShapeLayer.self }
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    let shapeLayer = self.layer as! CAShapeLayer
+    shapeLayer.path = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 100, height: 100)).cgPath
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+class UIKitBehavioralTests: XCTestCase {
+  var view: UIView!
+
+  var originalImplementation: IMP?
+  override func setUp() {
+    super.setUp()
+
+    let window = UIWindow()
+    window.makeKeyAndVisible()
+    view = ShapeLayerBackedView() // Need to animate a view's layer to get implicit animations.
+    window.addSubview(view)
+
+    // Connect our layers to the render server.
+    CATransaction.flush()
+  }
+
+  override func tearDown() {
+    view = nil
+
+    super.tearDown()
+  }
+
+  private func rebuildView() {
+    let oldSuperview = view.superview!
+    view.removeFromSuperview()
+    view = ShapeLayerBackedView() // Need to animate a view's layer to get implicit animations.
+    oldSuperview.addSubview(view)
+  }
+
+  func testSomePropertiesImplicitlyAnimateAdditively() {
+    let additiveProperties: [AnimatableKeyPath: Any] = [
+      .cornerRadius: 3,
+      .height: 100,
+      .position: CGPoint(x: 50, y: 20),
+      .rotation: 42,
+      .scale: 2.5,
+      .width: 25,
+      .x: 12,
+      .y: 23,
+    ]
+    for (keyPath, value) in additiveProperties {
+      rebuildView()
+
+      UIView.animate(withDuration: 0.01) {
+        self.view.layer.setValue(value, forKeyPath: keyPath.rawValue)
+      }
+
+      XCTAssertNotNil(view.layer.animationKeys(),
+                      "Expected \(keyPath.rawValue) to generate at least one animation.")
+      if let animationKeys = view.layer.animationKeys() {
+        for key in animationKeys {
+          let animation = view.layer.animation(forKey: key) as! CABasicAnimation
+          XCTAssertTrue(animation.isAdditive,
+                        "Expected \(key) to be additive as a result of animating "
+                        + "\(keyPath.rawValue), but it was not: \(animation.debugDescription).")
+        }
+      }
+    }
+  }
+
+  func testSomePropertiesImplicitlyAnimateButNotAdditively() {
+    let additiveProperties: [AnimatableKeyPath: Any] = [
+      .backgroundColor: UIColor.blue,
+      .opacity: 0.5,
+    ]
+    for (keyPath, value) in additiveProperties {
+      rebuildView()
+
+      UIView.animate(withDuration: 0.01) {
+        self.view.layer.setValue(value, forKeyPath: keyPath.rawValue)
+      }
+
+      XCTAssertNotNil(view.layer.animationKeys(),
+                      "Expected \(keyPath.rawValue) to generate at least one animation.")
+      if let animationKeys = view.layer.animationKeys() {
+        for key in animationKeys {
+          let animation = view.layer.animation(forKey: key) as! CABasicAnimation
+          XCTAssertFalse(animation.isAdditive,
+                        "Expected \(key) not to be additive as a result of animating "
+                        + "\(keyPath.rawValue), but it was: \(animation.debugDescription).")
+        }
+      }
+    }
+  }
+
+  func testSomePropertiesDoNotImplicitlyAnimate() {
+    let additiveProperties: [AnimatableKeyPath: Any] = [
+      .strokeStart: 0.2,
+      .strokeEnd: 0.5,
+    ]
+    for (keyPath, value) in additiveProperties {
+      self.view.layer.removeAllAnimations()
+
+      UIView.animate(withDuration: 0.01) {
+        self.view.layer.setValue(value, forKeyPath: keyPath.rawValue)
+      }
+
+      XCTAssertNil(view.layer.animationKeys(),
+                   "Expected \(keyPath.rawValue) not to generate any animations.")
+    }
+  }
+}
+

--- a/tests/unit/UIKitBehavioralTests.swift
+++ b/tests/unit/UIKitBehavioralTests.swift
@@ -45,7 +45,7 @@ class UIKitBehavioralTests: XCTestCase {
 
     let window = UIWindow()
     window.makeKeyAndVisible()
-    view = ShapeLayerBackedView() // Need to animate a view's layer to get implicit animations.
+    view = ShapeLayerBackedView()
     window.addSubview(view)
 
     // Connect our layers to the render server.

--- a/tests/unit/UIKitBehavioralTests.swift
+++ b/tests/unit/UIKitBehavioralTests.swift
@@ -48,8 +48,7 @@ class UIKitBehavioralTests: XCTestCase {
     view = ShapeLayerBackedView()
     window.addSubview(view)
 
-    // Connect our layers to the render server.
-    CATransaction.flush()
+    rebuildView()
   }
 
   override func tearDown() {
@@ -63,10 +62,13 @@ class UIKitBehavioralTests: XCTestCase {
     view.removeFromSuperview()
     view = ShapeLayerBackedView() // Need to animate a view's layer to get implicit animations.
     oldSuperview.addSubview(view)
+
+    // Connect our layers to the render server.
+    CATransaction.flush()
   }
 
   func testSomePropertiesImplicitlyAnimateAdditively() {
-    let additiveProperties: [AnimatableKeyPath: Any] = [
+    let properties: [AnimatableKeyPath: Any] = [
       .cornerRadius: 3,
       .height: 100,
       .position: CGPoint(x: 50, y: 20),
@@ -76,7 +78,7 @@ class UIKitBehavioralTests: XCTestCase {
       .x: 12,
       .y: 23,
     ]
-    for (keyPath, value) in additiveProperties {
+    for (keyPath, value) in properties {
       rebuildView()
 
       UIView.animate(withDuration: 0.01) {
@@ -97,11 +99,11 @@ class UIKitBehavioralTests: XCTestCase {
   }
 
   func testSomePropertiesImplicitlyAnimateButNotAdditively() {
-    let additiveProperties: [AnimatableKeyPath: Any] = [
+    let properties: [AnimatableKeyPath: Any] = [
       .backgroundColor: UIColor.blue,
       .opacity: 0.5,
     ]
-    for (keyPath, value) in additiveProperties {
+    for (keyPath, value) in properties {
       rebuildView()
 
       UIView.animate(withDuration: 0.01) {
@@ -122,12 +124,12 @@ class UIKitBehavioralTests: XCTestCase {
   }
 
   func testSomePropertiesDoNotImplicitlyAnimate() {
-    let additiveProperties: [AnimatableKeyPath: Any] = [
+    let properties: [AnimatableKeyPath: Any] = [
       .strokeStart: 0.2,
       .strokeEnd: 0.5,
     ]
-    for (keyPath, value) in additiveProperties {
-      self.view.layer.removeAllAnimations()
+    for (keyPath, value) in properties {
+      rebuildView()
 
       UIView.animate(withDuration: 0.01) {
         self.view.layer.setValue(value, forKeyPath: keyPath.rawValue)


### PR DESCRIPTION
These tests provide a baseline of expectations for how different key paths are expected to animate in UIKit. These tests serve both as educational ("What can I animate with UIKit?") as well as as a measure of our own adherence to the baseline expectations.

For example, as a result of these unit tests it is now clear that we should not be additively animating opacity by default.