### PR TITLE
Add UIKit behavioral test verifying that layer values never implicitly animate outside of an animation block.

### DIFF
--- a/tests/unit/UIKitBehavioralTests.swift
+++ b/tests/unit/UIKitBehavioralTests.swift
@@ -67,6 +67,8 @@ class UIKitBehavioralTests: XCTestCase {
     CATransaction.flush()
   }
 
+  // MARK: Each animatable property needs to be added to exactly one of the following three tests
+
   func testSomePropertiesImplicitlyAnimateAdditively() {
     let properties: [AnimatableKeyPath: Any] = [
       .cornerRadius: 3,
@@ -139,6 +141,8 @@ class UIKitBehavioralTests: XCTestCase {
                    "Expected \(keyPath.rawValue) not to generate any animations.")
     }
   }
+
+  // MARK: Every animatable layer property must be added to the following test
 
   func testNoPropertiesImplicitlyAnimateOutsideOfAnAnimationBlock() {
     let properties: [AnimatableKeyPath: Any] = [

--- a/tests/unit/UIKitBehavioralTests.swift
+++ b/tests/unit/UIKitBehavioralTests.swift
@@ -139,5 +139,29 @@ class UIKitBehavioralTests: XCTestCase {
                    "Expected \(keyPath.rawValue) not to generate any animations.")
     }
   }
-}
 
+  func testNoPropertiesImplicitlyAnimateOutsideOfAnAnimationBlock() {
+    let properties: [AnimatableKeyPath: Any] = [
+      .backgroundColor: UIColor.blue,
+      .cornerRadius: 3,
+      .height: 100,
+      .opacity: 0.5,
+      .position: CGPoint(x: 50, y: 20),
+      .rotation: 42,
+      .scale: 2.5,
+      .strokeStart: 0.2,
+      .strokeEnd: 0.5,
+      .width: 25,
+      .x: 12,
+      .y: 23,
+    ]
+    for (keyPath, value) in properties {
+      rebuildView()
+
+      self.view.layer.setValue(value, forKeyPath: keyPath.rawValue)
+
+      XCTAssertNil(view.layer.animationKeys(),
+                   "Expected \(keyPath.rawValue) not to generate any animations.")
+    }
+  }
+}


### PR DESCRIPTION
Continued documentation of our understanding of UIKit's animation behaviors.