### PR TITLE
Only implicitly animate supported key paths.

### DIFF
--- a/tests/unit/ImplicitAnimationTests.swift
+++ b/tests/unit/ImplicitAnimationTests.swift
@@ -209,4 +209,14 @@ class ImplicitAnimationTests: XCTestCase {
 
     XCTAssertEqual(view.layer.animationKeys()!, ["opacity"])
   }
+
+  func testUnsupportedAnimationKeyIsNotAnimated() {
+    animator.animate(with: timing) {
+      self.view.layer.sublayers = []
+    }
+
+    XCTAssertNil(view.layer.animationKeys(),
+                 "No animations should have been added, but the following keys were found: "
+                  + "\(view.layer.animationKeys()!)")
+  }
 }


### PR DESCRIPTION
This API allows us to have a whitelist of supported implicitly-animatable key paths. Without this, it can be easy to accidentally attempt to animate keypaths such as `sublayers` or private APIs that we shouldn't be accessing.