### PR TITLE
Fix bug where beginFromCurrentState would not start from the current model/presentation value.

### DIFF
--- a/examples/apps/Catalog/MotionAnimatorCatalog.xcodeproj/project.pbxproj
+++ b/examples/apps/Catalog/MotionAnimatorCatalog.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		664F59961FCDB2E6002EC56D /* QuartzCoreBehavioralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664F59951FCDB2E5002EC56D /* QuartzCoreBehavioralTests.swift */; };
 		664F599A1FCE6661002EC56D /* NonAdditiveAnimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664F59991FCE6661002EC56D /* NonAdditiveAnimatorTests.swift */; };
 		664F599C1FCE67DB002EC56D /* AdditiveAnimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664F599B1FCE67DB002EC56D /* AdditiveAnimatorTests.swift */; };
+		664F59981FCE5CE2002EC56D /* BeginFromCurrentStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664F59971FCE5CE2002EC56D /* BeginFromCurrentStateTests.swift */; };
 		666FAA841D384A6B000363DA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666FAA831D384A6B000363DA /* AppDelegate.swift */; };
 		666FAA8B1D384A6B000363DA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 666FAA8A1D384A6B000363DA /* Assets.xcassets */; };
 		666FAA8E1D384A6B000363DA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 666FAA8C1D384A6B000363DA /* LaunchScreen.storyboard */; };
@@ -59,6 +60,7 @@
 		664F59951FCDB2E5002EC56D /* QuartzCoreBehavioralTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuartzCoreBehavioralTests.swift; sourceTree = "<group>"; };
 		664F59991FCE6661002EC56D /* NonAdditiveAnimatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAdditiveAnimatorTests.swift; sourceTree = "<group>"; };
 		664F599B1FCE67DB002EC56D /* AdditiveAnimatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdditiveAnimatorTests.swift; sourceTree = "<group>"; };
+		664F59971FCE5CE2002EC56D /* BeginFromCurrentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeginFromCurrentStateTests.swift; sourceTree = "<group>"; };
 		666FAA801D384A6B000363DA /* MotionAnimatorCatalog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MotionAnimatorCatalog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		666FAA831D384A6B000363DA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Catalog/AppDelegate.swift; sourceTree = "<group>"; };
 		666FAA8A1D384A6B000363DA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -224,6 +226,7 @@
 			children = (
 				664F599B1FCE67DB002EC56D /* AdditiveAnimatorTests.swift */,
 				66A6A6671FBA158000DE54CB /* AnimationRemovalTests.swift */,
+				664F59971FCE5CE2002EC56D /* BeginFromCurrentStateTests.swift */,
 				66EF6F271FC33C4800C83A63 /* HeadlessLayerImplicitAnimationTests.swift */,
 				66BF5A8E1FB0E4CB00E864F6 /* ImplicitAnimationTests.swift */,
 				6625876B1FB4DB9C00BC7DF1 /* InitialVelocityTests.swift */,
@@ -520,6 +523,7 @@
 				664F599C1FCE67DB002EC56D /* AdditiveAnimatorTests.swift in Sources */,
 				66A6A6681FBA158000DE54CB /* AnimationRemovalTests.swift in Sources */,
 				6687264A1EF04B4C00113675 /* MotionAnimatorTests.swift in Sources */,
+				664F59981FCE5CE2002EC56D /* BeginFromCurrentStateTests.swift in Sources */,
 				66FD99FA1EE9FBBE00C53A82 /* MotionAnimatorTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -59,12 +59,16 @@
   }
   values = MDMCoerceUIKitValuesToCoreAnimationValues(values);
 
-  [CATransaction begin];
-  [CATransaction setDisableActions:YES];
-  [layer setValue:[values lastObject] forKeyPath:keyPath];
-  [CATransaction commit];
+  void (^commitToModelLayer)(void) = ^{
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    [layer setValue:[values lastObject] forKeyPath:keyPath];
+    [CATransaction commit];
+  };
 
   void (^exitEarly)(void) = ^{
+    commitToModelLayer();
+
     if (completion) {
       completion();
     }
@@ -114,6 +118,8 @@
 
   NSString *key = _additive ? nil : keyPath;
   [_registrar addAnimation:animation toLayer:layer forKey:key completion:completion];
+
+  commitToModelLayer();
 
   for (void (^tracer)(CALayer *, CAAnimation *) in _tracers) {
     tracer(layer, animation);

--- a/tests/unit/BeginFromCurrentStateTests.swift
+++ b/tests/unit/BeginFromCurrentStateTests.swift
@@ -83,11 +83,12 @@ class BeginFromCurrentStateTests: XCTestCase {
       return
     }
 
-    XCTAssertEqual(fromValue, initialValue,
-                   "Expected the animation to start from \(initialValue), but it did not.")
+    XCTAssertEqualWithAccuracy(fromValue, initialValue, accuracy: 0.0001,
+                               "Expected the animation to start from \(initialValue), "
+                                + "but it did not.")
 
-    XCTAssertEqual(view.layer.opacity, 0.5,
-                   "The layer's opacity was not set to the animation's final value.")
+    XCTAssertEqualWithAccuracy(view.layer.opacity, 0.5, accuracy: 0.0001,
+                               "The layer's opacity was not set to the animation's final value.")
   }
 
   func testImplicitlyAnimatesFromModelValue() {
@@ -119,11 +120,12 @@ class BeginFromCurrentStateTests: XCTestCase {
       return
     }
 
-    XCTAssertEqual(fromValue, initialValue,
-                   "Expected the animation to start from \(initialValue), but it did not.")
+    XCTAssertEqualWithAccuracy(fromValue, initialValue, accuracy: 0.0001,
+                               "Expected the animation to start from \(initialValue), "
+                                + "but it did not.")
 
-    XCTAssertEqual(view.layer.opacity, 0.5,
-                   "The layer's opacity was not set to the animation's final value.")
+    XCTAssertEqualWithAccuracy(view.layer.opacity, 0.5, accuracy: 0.0001,
+                               "The layer's opacity was not set to the animation's final value.")
   }
 
   func testExplicitlyAnimatesFromPresentationValue() {
@@ -160,11 +162,12 @@ class BeginFromCurrentStateTests: XCTestCase {
       return
     }
 
-    XCTAssertEqual(fromValue, initialValue,
-                   "Expected the animation to start from \(initialValue), but it did not.")
+    XCTAssertEqualWithAccuracy(fromValue, initialValue, accuracy: 0.0001,
+                               "Expected the animation to start from \(initialValue), "
+                                + "but it did not.")
 
-    XCTAssertEqual(view.layer.opacity, 0.2,
-                   "The layer's opacity was not set to the animation's final value.")
+    XCTAssertEqualWithAccuracy(view.layer.opacity, 0.2, accuracy: 0.0001,
+                               "The layer's opacity was not set to the animation's final value.")
   }
 
   func testImplicitlyAnimatesFromPresentationValue() {
@@ -204,10 +207,11 @@ class BeginFromCurrentStateTests: XCTestCase {
       return
     }
 
-    XCTAssertEqual(fromValue, initialValue,
-                   "Expected the animation to start from \(initialValue), but it did not.")
+    XCTAssertEqualWithAccuracy(fromValue, initialValue, accuracy: 0.0001,
+                               "Expected the animation to start from \(initialValue), "
+                                + "but it did not.")
 
-    XCTAssertEqual(view.layer.opacity, 0.2,
-                   "The layer's opacity was not set to the animation's final value.")
+    XCTAssertEqualWithAccuracy(view.layer.opacity, 0.2, accuracy: 0.0001,
+                               "The layer's opacity was not set to the animation's final value.")
   }
 }

--- a/tests/unit/BeginFromCurrentStateTests.swift
+++ b/tests/unit/BeginFromCurrentStateTests.swift
@@ -1,0 +1,213 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+
+#if IS_BAZEL_BUILD
+import _MotionAnimator
+#else
+import MotionAnimator
+#endif
+
+class BeginFromCurrentStateTests: XCTestCase {
+  var animator: MotionAnimator!
+  var timing: MotionTiming!
+  var view: UIView!
+
+  override func setUp() {
+    super.setUp()
+
+    animator = MotionAnimator()
+
+    animator.beginFromCurrentState = true
+
+    timing = MotionTiming(delay: 0,
+                          duration: 1,
+                          curve: MotionCurveMakeBezier(p1x: 0, p1y: 0, p2x: 0, p2y: 0),
+                          repetition: .init(type: .none, amount: 0, autoreverses: false))
+
+    let window = UIWindow()
+    window.makeKeyAndVisible()
+    view = UIView() // Need to animate a view's layer to get implicit animations.
+    window.addSubview(view)
+
+    // Connect our layers to the render server.
+    CATransaction.flush()
+  }
+
+  override func tearDown() {
+    animator = nil
+    timing = nil
+    view = nil
+
+    super.tearDown()
+  }
+
+  func testExplicitlyAnimatesFromModelValue() {
+    let initialValue = view.layer.opacity
+
+    animator.additive = false
+
+    animator.animate(with: timing, to: view.layer, withValues: [0, 0.5], keyPath: .opacity)
+
+    XCTAssertNotNil(view.layer.animationKeys(),
+                    "Expected an animation to be added, but none were found.")
+    guard let animationKeys = view.layer.animationKeys() else {
+      return
+    }
+    XCTAssertEqual(animationKeys.count, 1,
+                   "Expected only one animation to be added, but the following were found: "
+                    + "\(animationKeys).")
+    guard let key = animationKeys.first,
+        let animation = view.layer.animation(forKey: key) as? CABasicAnimation else {
+      return
+    }
+
+    XCTAssertTrue(animation.fromValue is Float,
+                  "The animation's from value was not a number type: "
+                    + String(describing: animation.fromValue))
+    guard let fromValue = animation.fromValue as? Float else {
+      return
+    }
+
+    XCTAssertEqual(fromValue, initialValue,
+                   "Expected the animation to start from \(initialValue), but it did not.")
+
+    XCTAssertEqual(view.layer.opacity, 0.5,
+                   "The layer's opacity was not set to the animation's final value.")
+  }
+
+  func testImplicitlyAnimatesFromModelValue() {
+    let initialValue = view.layer.opacity
+
+    animator.additive = false
+
+    animator.animate(with: timing) {
+      self.view.alpha = 0.5
+    }
+
+    XCTAssertNotNil(view.layer.animationKeys(),
+                    "Expected an animation to be added, but none were found.")
+    guard let animationKeys = view.layer.animationKeys() else {
+      return
+    }
+    XCTAssertEqual(animationKeys.count, 1,
+                   "Expected only one animation to be added, but the following were found: "
+                    + "\(animationKeys).")
+    guard let key = animationKeys.first,
+      let animation = view.layer.animation(forKey: key) as? CABasicAnimation else {
+        return
+    }
+
+    XCTAssertTrue(animation.fromValue is Float,
+                  "The animation's from value was not a number type: "
+                    + String(describing: animation.fromValue))
+    guard let fromValue = animation.fromValue as? Float else {
+      return
+    }
+
+    XCTAssertEqual(fromValue, initialValue,
+                   "Expected the animation to start from \(initialValue), but it did not.")
+
+    XCTAssertEqual(view.layer.opacity, 0.5,
+                   "The layer's opacity was not set to the animation's final value.")
+  }
+
+  func testExplicitlyAnimatesFromPresentationValue() {
+    animator.additive = false
+
+    animator.animate(with: timing, to: view.layer, withValues: [0, 0.5], keyPath: .opacity)
+    RunLoop.main.run(until: .init(timeIntervalSinceNow: 0.01))
+
+    XCTAssertNotNil(view.layer.presentation(), "No presentation layer found.")
+    guard let presentation = view.layer.presentation() else {
+      return
+    }
+    let initialValue = presentation.opacity
+
+    animator.animate(with: timing, to: view.layer, withValues: [0, 0.2], keyPath: .opacity)
+
+    XCTAssertNotNil(view.layer.animationKeys(),
+                    "Expected an animation to be added, but none were found.")
+    guard let animationKeys = view.layer.animationKeys() else {
+      return
+    }
+    XCTAssertEqual(animationKeys.count, 1,
+                   "Expected only one animation to be added, but the following were found: "
+                    + "\(animationKeys).")
+    guard let key = animationKeys.first,
+      let animation = view.layer.animation(forKey: key) as? CABasicAnimation else {
+        return
+    }
+
+    XCTAssertTrue(animation.fromValue is Float,
+                  "The animation's from value was not a number type: "
+                    + String(describing: animation.fromValue))
+    guard let fromValue = animation.fromValue as? Float else {
+      return
+    }
+
+    XCTAssertEqual(fromValue, initialValue,
+                   "Expected the animation to start from \(initialValue), but it did not.")
+
+    XCTAssertEqual(view.layer.opacity, 0.2,
+                   "The layer's opacity was not set to the animation's final value.")
+  }
+
+  func testImplicitlyAnimatesFromPresentationValue() {
+    animator.additive = false
+
+    animator.animate(with: timing, to: view.layer, withValues: [0, 0.5], keyPath: .opacity)
+
+    RunLoop.main.run(until: .init(timeIntervalSinceNow: 0.01))
+
+    XCTAssertNotNil(view.layer.presentation(), "No presentation layer found.")
+    guard let presentation = view.layer.presentation() else {
+      return
+    }
+    let initialValue = presentation.opacity
+
+    animator.animate(with: timing) {
+      self.view.alpha = 0.2
+    }
+
+    XCTAssertNotNil(view.layer.animationKeys(),
+                    "Expected an animation to be added, but none were found.")
+    guard let animationKeys = view.layer.animationKeys() else {
+      return
+    }
+    XCTAssertEqual(animationKeys.count, 1,
+                   "Expected only one animation to be added, but the following were found: "
+                    + "\(animationKeys).")
+    guard let key = animationKeys.first,
+      let animation = view.layer.animation(forKey: key) as? CABasicAnimation else {
+        return
+    }
+
+    XCTAssertTrue(animation.fromValue is Float,
+                  "The animation's from value was not a number type: "
+                    + String(describing: animation.fromValue))
+    guard let fromValue = animation.fromValue as? Float else {
+      return
+    }
+
+    XCTAssertEqual(fromValue, initialValue,
+                   "Expected the animation to start from \(initialValue), but it did not.")
+
+    XCTAssertEqual(view.layer.opacity, 0.2,
+                   "The layer's opacity was not set to the animation's final value.")
+  }
+}


### PR DESCRIPTION
This was due to the fact that we began writing the animation's toValue to the model layer at the beginning of the animate implementation in 5a3d65e32ee990561392983d9bc9b359e903594b.

Added a test to catch regressions in the future.