### PR TITLE
Check for divide-by-zero before calculating the initial velocity of spring animations.

### DIFF
--- a/src/private/CABasicAnimation+MotionAnimator.h
+++ b/src/private/CABasicAnimation+MotionAnimator.h
@@ -33,6 +33,4 @@ FOUNDATION_EXPORT BOOL MDMCanAnimationBeAdditive(NSString *keyPath, id toValue);
 //
 // Not all animation value types support being additive. If an animation's value type was not
 // supported, the animation's values will not be modified.
-//
-// If the from and to values of the animation match then the behavior is undefined.
 FOUNDATION_EXPORT void MDMConfigureAnimation(CABasicAnimation *animation, MDMMotionTiming timing);

--- a/src/private/CABasicAnimation+MotionAnimator.m
+++ b/src/private/CABasicAnimation+MotionAnimator.m
@@ -19,6 +19,15 @@
 #import "CAMediaTimingFunction+MotionAnimator.h"
 
 #import <UIKit/UIKit.h>
+#import <tgmath.h>
+
+#ifndef CGFLOAT_EPSILON
+#if CGFLOAT_IS_DOUBLE
+#define CGFLOAT_EPSILON DBL_EPSILON
+#else
+#define CGFLOAT_EPSILON FLT_EPSILON
+#endif  // CGFLOAT_IS_DOUBLE
+#endif  // CGFLOAT_EPSILON
 
 #pragma mark - Private
 
@@ -180,7 +189,7 @@ void MDMConfigureAnimation(CABasicAnimation *animation, MDMMotionTiming timing) 
       // As for our sign, if absoluteInitialVelocity matches the direction of displacement, then our
       // sign will be positive. Otherwise, our sign will be negative, as expected by Core Animation.
 
-      if (displacement != 0) {
+      if (fabs(displacement) > CGFLOAT_EPSILON) {
         springAnimation.initialVelocity = absoluteInitialVelocity / displacement;
       }
     }
@@ -213,7 +222,7 @@ void MDMConfigureAnimation(CABasicAnimation *animation, MDMMotionTiming timing) 
       CGFloat displacement = -biggestDelta;
       CGFloat absoluteInitialVelocity =
           timing.curve.data[MDMSpringMotionCurveDataIndexInitialVelocity];
-      if (displacement != 0) {
+      if (fabs(displacement) > CGFLOAT_EPSILON) {
         springAnimation.initialVelocity = absoluteInitialVelocity / displacement;
       }
     }
@@ -246,7 +255,7 @@ void MDMConfigureAnimation(CABasicAnimation *animation, MDMMotionTiming timing) 
       CGFloat displacement = -biggestDelta;
       CGFloat absoluteInitialVelocity =
           timing.curve.data[MDMSpringMotionCurveDataIndexInitialVelocity];
-      if (displacement != 0) {
+      if (fabs(displacement) > CGFLOAT_EPSILON) {
         springAnimation.initialVelocity = absoluteInitialVelocity / displacement;
       }
     }

--- a/src/private/CABasicAnimation+MotionAnimator.m
+++ b/src/private/CABasicAnimation+MotionAnimator.m
@@ -180,7 +180,9 @@ void MDMConfigureAnimation(CABasicAnimation *animation, MDMMotionTiming timing) 
       // As for our sign, if absoluteInitialVelocity matches the direction of displacement, then our
       // sign will be positive. Otherwise, our sign will be negative, as expected by Core Animation.
 
-      springAnimation.initialVelocity = absoluteInitialVelocity / displacement;
+      if (displacement != 0) {
+        springAnimation.initialVelocity = absoluteInitialVelocity / displacement;
+      }
     }
 
   } else if (IsCGSizeType(animation.toValue)) {
@@ -211,7 +213,9 @@ void MDMConfigureAnimation(CABasicAnimation *animation, MDMMotionTiming timing) 
       CGFloat displacement = -biggestDelta;
       CGFloat absoluteInitialVelocity =
           timing.curve.data[MDMSpringMotionCurveDataIndexInitialVelocity];
-      springAnimation.initialVelocity = absoluteInitialVelocity / displacement;
+      if (displacement != 0) {
+        springAnimation.initialVelocity = absoluteInitialVelocity / displacement;
+      }
     }
 
   } else if (IsCGPointType(animation.toValue)) {
@@ -242,7 +246,9 @@ void MDMConfigureAnimation(CABasicAnimation *animation, MDMMotionTiming timing) 
       CGFloat displacement = -biggestDelta;
       CGFloat absoluteInitialVelocity =
           timing.curve.data[MDMSpringMotionCurveDataIndexInitialVelocity];
-      springAnimation.initialVelocity = absoluteInitialVelocity / displacement;
+      if (displacement != 0) {
+        springAnimation.initialVelocity = absoluteInitialVelocity / displacement;
+      }
     }
   }
 

--- a/src/private/CABasicAnimation+MotionAnimator.m
+++ b/src/private/CABasicAnimation+MotionAnimator.m
@@ -19,7 +19,6 @@
 #import "CAMediaTimingFunction+MotionAnimator.h"
 
 #import <UIKit/UIKit.h>
-#import <tgmath.h>
 
 #pragma mark - Private
 

--- a/src/private/CABasicAnimation+MotionAnimator.m
+++ b/src/private/CABasicAnimation+MotionAnimator.m
@@ -21,14 +21,6 @@
 #import <UIKit/UIKit.h>
 #import <tgmath.h>
 
-#ifndef CGFLOAT_EPSILON
-#if CGFLOAT_IS_DOUBLE
-#define CGFLOAT_EPSILON DBL_EPSILON
-#else
-#define CGFLOAT_EPSILON FLT_EPSILON
-#endif  // CGFLOAT_IS_DOUBLE
-#endif  // CGFLOAT_EPSILON
-
 #pragma mark - Private
 
 static BOOL IsNumberValue(id someValue) {
@@ -189,7 +181,7 @@ void MDMConfigureAnimation(CABasicAnimation *animation, MDMMotionTiming timing) 
       // As for our sign, if absoluteInitialVelocity matches the direction of displacement, then our
       // sign will be positive. Otherwise, our sign will be negative, as expected by Core Animation.
 
-      if (fabs(displacement) > CGFLOAT_EPSILON) {
+      if (fabs(displacement) > 0.00001) {
         springAnimation.initialVelocity = absoluteInitialVelocity / displacement;
       }
     }
@@ -222,7 +214,7 @@ void MDMConfigureAnimation(CABasicAnimation *animation, MDMMotionTiming timing) 
       CGFloat displacement = -biggestDelta;
       CGFloat absoluteInitialVelocity =
           timing.curve.data[MDMSpringMotionCurveDataIndexInitialVelocity];
-      if (fabs(displacement) > CGFLOAT_EPSILON) {
+      if (fabs(displacement) > 0.00001) {
         springAnimation.initialVelocity = absoluteInitialVelocity / displacement;
       }
     }
@@ -255,7 +247,7 @@ void MDMConfigureAnimation(CABasicAnimation *animation, MDMMotionTiming timing) 
       CGFloat displacement = -biggestDelta;
       CGFloat absoluteInitialVelocity =
           timing.curve.data[MDMSpringMotionCurveDataIndexInitialVelocity];
-      if (fabs(displacement) > CGFLOAT_EPSILON) {
+      if (fabs(displacement) > 0.00001) {
         springAnimation.initialVelocity = absoluteInitialVelocity / displacement;
       }
     }


### PR DESCRIPTION
This improves the robustness of MDMConfigureAnimation while enabling us to call the method without having to check whether the from/to value are equal.