### PR TITLE
Ensure that non-additive animations begin from the presentation layer state when beginFromCurrentState is enabled

### DIFF
--- a/src/private/CABasicAnimation+MotionAnimator.h
+++ b/src/private/CABasicAnimation+MotionAnimator.h
@@ -24,13 +24,15 @@
 FOUNDATION_EXPORT
 CABasicAnimation *MDMAnimationFromTiming(MDMMotionTiming timing, CGFloat timeScaleFactor);
 
-// Attempts to configure the provided animation to be additive and, if the animation is a spring
-// animation, will extract the initial velocity from the timing and apply it to the animation.
+// Returns a Boolean indicating whether or not an animation with the given key path and toValue
+// can be animated additively.
+FOUNDATION_EXPORT BOOL MDMCanAnimationBeAdditive(NSString *keyPath, id toValue);
+
+// If the animation's additive property is enabled, then its from/to values will be transformed into
+// additive equivalents.
 //
 // Not all animation value types support being additive. If an animation's value type was not
 // supported, the animation's values will not be modified.
 //
 // If the from and to values of the animation match then the behavior is undefined.
-FOUNDATION_EXPORT void MDMConfigureAnimation(CABasicAnimation *animation,
-                                             BOOL wantsAdditive,
-                                             MDMMotionTiming timing);
+FOUNDATION_EXPORT void MDMConfigureAnimation(CABasicAnimation *animation, MDMMotionTiming timing);

--- a/src/private/CABasicAnimation+MotionAnimator.m
+++ b/src/private/CABasicAnimation+MotionAnimator.m
@@ -86,10 +86,12 @@ CABasicAnimation *MDMAnimationFromTiming(MDMMotionTiming timing, CGFloat timeSca
   return animation;
 }
 
-void MDMConfigureAnimation(CABasicAnimation *animation,
-                           BOOL wantsAdditive,
-                           MDMMotionTiming timing) {
-  if (!wantsAdditive && timing.curve.type != MDMMotionCurveTypeSpring) {
+BOOL MDMCanAnimationBeAdditive(NSString *keyPath, id toValue) {
+  return IsNumberValue(toValue) || IsCGSizeType(toValue) || IsCGPointType(toValue);
+}
+
+void MDMConfigureAnimation(CABasicAnimation *animation, MDMMotionTiming timing) {
+  if (!animation.additive && timing.curve.type != MDMMotionCurveTypeSpring) {
     return; // Nothing to do here.
   }
 
@@ -126,10 +128,9 @@ void MDMConfigureAnimation(CABasicAnimation *animation,
     CGFloat displacement = to - from;
     CGFloat additiveDisplacement = -displacement;
 
-    if (wantsAdditive) {
+    if (animation.additive) {
       animation.fromValue = @(additiveDisplacement);
       animation.toValue = @0;
-      animation.additive = true;
     }
 
 #pragma clang diagnostic push
@@ -187,10 +188,9 @@ void MDMConfigureAnimation(CABasicAnimation *animation,
     CGSize to = [animation.toValue CGSizeValue];
     CGSize additiveDisplacement = CGSizeMake(from.width - to.width, from.height - to.height);
 
-    if (wantsAdditive) {
+    if (animation.additive) {
       animation.fromValue = [NSValue valueWithCGSize:additiveDisplacement];
       animation.toValue = [NSValue valueWithCGSize:CGSizeZero];
-      animation.additive = true;
     }
 
 #pragma clang diagnostic push
@@ -219,10 +219,9 @@ void MDMConfigureAnimation(CABasicAnimation *animation,
     CGPoint to = [animation.toValue CGPointValue];
     CGPoint additiveDisplacement = CGPointMake(from.x - to.x, from.y - to.y);
 
-    if (wantsAdditive) {
+    if (animation.additive) {
       animation.fromValue = [NSValue valueWithCGPoint:additiveDisplacement];
       animation.toValue = [NSValue valueWithCGPoint:CGPointZero];
-      animation.additive = true;
     }
 
 #pragma clang diagnostic push


### PR DESCRIPTION
When beginFromCurrentState is enabled, the user expects any new animations to animate from the layer's current presentation state.

What this actually means in practice depends on whether the new animation is additive or not.

If the animation is additive, we always want to read from the model layer because we need to calculate displacement from the old destination to the new destination.

If the animation is not additive, we read from the presentation layer if available so that the view begins animating from its current rendered position.

The difference between the two approaches is that additive animations will always appear to preserve momentum - potentially even moving in the opposite direction for a brief moment - while non-additive animations will instantly begin moving toward the new destination.