### PR TITLE
Refactor common code from explicit/implicit animation implementations.

### DIFF
--- a/src/MDMMotionAnimator.h
+++ b/src/MDMMotionAnimator.h
@@ -42,7 +42,9 @@ NS_SWIFT_NAME(MotionAnimator)
 @property(nonatomic, assign) CGFloat timeScaleFactor;
 
 /**
- If enabled, all animations will be added with their values reversed.
+ If enabled, explicitly-provided values will be reversed before animating.
+
+ This property does not affect the animateWithTiming:animations: family of methods.
 
  Disabled by default.
  */

--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -109,6 +109,10 @@
         } completion:completion];
 
   commitToModelLayer();
+
+  for (void (^tracer)(CALayer *, CAAnimation *) in _tracers) {
+    tracer(layer, animation);
+  }
 }
 
 - (void)animateWithTiming:(MDMMotionTiming)timing animations:(void (^)(void))animations {
@@ -159,6 +163,10 @@
                  return action.initialModelValue;
                }
              } completion:nil];
+
+    for (void (^tracer)(CALayer *, CAAnimation *) in _tracers) {
+      tracer(action.layer, animation);
+    }
   }
 
   [CATransaction commit];
@@ -233,10 +241,6 @@
   }
 
   [_registrar addAnimation:animation toLayer:layer forKey:key completion:completion];
-
-  for (void (^tracer)(CALayer *, CAAnimation *) in _tracers) {
-    tracer(layer, animation);
-  }
 }
 
 @end

--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -87,55 +87,28 @@
     return;
   }
 
-  animation.keyPath = keyPath;
-  animation.toValue = [values lastObject];
+  BOOL beginFromCurrentState = self.beginFromCurrentState;
 
-  animation.additive = self.additive && MDMCanAnimationBeAdditive(keyPath, animation.toValue);
+  [self addAnimation:animation
+             toLayer:layer
+         withKeyPath:keyPath
+              timing:timing
+     timeScaleFactor:timeScaleFactor
+         destination:[values lastObject]
+        initialValue:^(BOOL wantsPresentationValue) {
+          if (beginFromCurrentState) {
+            if (wantsPresentationValue && [layer presentationLayer]) {
+              return [[layer presentationLayer] valueForKeyPath:keyPath];
+            } else {
+              return [layer valueForKeyPath:keyPath];
+            }
+          } else {
+            return [values firstObject];
+          }
 
-  // Now that we know whether the animation will be additive, we can calculate the from value.
-  id fromValue;
-  if (self.beginFromCurrentState) {
-    // Additive animations always read from the model layer's value so that the new displacement
-    // reflects the change in destination and momentum appears to be conserved across multiple
-    // animations.
-    //
-    // Non-additive animations should try to read from the presentation layer's current value
-    // because we'll be interrupting whatever animation previously existed and immediately moving
-    // toward the new destination.
-    BOOL wantsPresentationValue = !animation.additive;
-
-    if (wantsPresentationValue && [layer presentationLayer]) {
-      fromValue = [[layer presentationLayer] valueForKeyPath:keyPath];
-    } else {
-      fromValue = [layer valueForKeyPath:keyPath];
-    }
-  } else {
-    fromValue = [values firstObject];
-  }
-
-  animation.fromValue = fromValue;
-
-  if ([animation.fromValue isEqual:animation.toValue]) {
-    exitEarly();
-    return;
-  }
-
-  MDMConfigureAnimation(animation, timing);
-
-  if (timing.delay != 0) {
-    animation.beginTime = ([layer convertTime:CACurrentMediaTime() fromLayer:nil]
-                           + timing.delay * timeScaleFactor);
-    animation.fillMode = kCAFillModeBackwards;
-  }
-
-  NSString *key = _additive ? nil : keyPath;
-  [_registrar addAnimation:animation toLayer:layer forKey:key completion:completion];
+        } completion:completion];
 
   commitToModelLayer();
-
-  for (void (^tracer)(CALayer *, CAAnimation *) in _tracers) {
-    tracer(layer, animation);
-  }
 }
 
 - (void)animateWithTiming:(MDMMotionTiming)timing animations:(void (^)(void))animations {
@@ -147,15 +120,45 @@
                completion:(void(^)(void))completion {
   NSArray<MDMImplicitAction *> *actions = MDMAnimateImplicitly(animations);
 
+  void (^exitEarly)(void) = ^{
+    if (completion) {
+      completion();
+    }
+  };
+
+  CGFloat timeScaleFactor = [self computedTimeScaleFactor];
+  if (timeScaleFactor == 0) {
+    exitEarly();
+    return; // No need to animate anything.
+  }
+
+  // We'll reuse this animation template for each action.
+  CABasicAnimation *animationTemplate = MDMAnimationFromTiming(timing, timeScaleFactor);
+  if (animationTemplate == nil) {
+    exitEarly();
+    return;
+  }
+
   [CATransaction begin];
   [CATransaction setCompletionBlock:completion];
 
   for (MDMImplicitAction *action in actions) {
-    id currentValue = [action.layer valueForKeyPath:action.keyPath];
-    [self animateWithTiming:timing
-                    toLayer:action.layer
-                 withValues:@[action.initialValue, currentValue]
-                    keyPath:action.keyPath];
+    CABasicAnimation *animation = [animationTemplate copy];
+
+    [self addAnimation:animation
+               toLayer:action.layer
+           withKeyPath:action.keyPath
+                timing:timing
+       timeScaleFactor:timeScaleFactor
+           destination:[action.layer valueForKeyPath:action.keyPath]
+          initialValue:^(BOOL wantsPresentationValue) {
+               if (wantsPresentationValue && action.hadPresentationLayer) {
+                 return action.initialPresentationValue;
+               } else {
+                 // Additive animations always animate from the initial model layer value.
+                 return action.initialModelValue;
+               }
+             } completion:nil];
   }
 
   [CATransaction commit];
@@ -193,6 +196,47 @@
   }
 
   return MDMSimulatorAnimationDragCoefficient() * timeScaleFactor;
+}
+
+- (void)addAnimation:(CABasicAnimation *)animation
+             toLayer:(CALayer *)layer
+         withKeyPath:(NSString *)keyPath
+              timing:(MDMMotionTiming)timing
+     timeScaleFactor:(CGFloat)timeScaleFactor
+         destination:(id)destination
+        initialValue:(id(^)(BOOL wantsPresentationValue))initialValueBlock
+          completion:(void(^)(void))completion {
+  // Must configure the keyPath and toValue before we can identify whether the animation supports
+  // being additive.
+  animation.keyPath = keyPath;
+  animation.toValue = destination;
+  animation.additive = self.additive && MDMCanAnimationBeAdditive(keyPath, animation.toValue);
+
+  // Additive animations always read from the model layer's value so that the new displacement
+  // reflects the change in destination and momentum appears to be conserved across multiple
+  // animations.
+  //
+  // Non-additive animations should try to read from the presentation layer's current value
+  // because we'll be interrupting whatever animation previously existed and immediately moving
+  // toward the new destination.
+  BOOL wantsPresentationValue = self.beginFromCurrentState && !animation.additive;
+  animation.fromValue = initialValueBlock(wantsPresentationValue);
+
+  NSString *key = animation.additive ? nil : keyPath;
+
+  MDMConfigureAnimation(animation, timing);
+
+  if (timing.delay != 0) {
+    animation.beginTime = ([layer convertTime:CACurrentMediaTime() fromLayer:nil]
+                           + timing.delay * timeScaleFactor);
+    animation.fillMode = kCAFillModeBackwards;
+  }
+
+  [_registrar addAnimation:animation toLayer:layer forKey:key completion:completion];
+
+  for (void (^tracer)(CALayer *, CAAnimation *) in _tracers) {
+    tracer(layer, animation);
+  }
 }
 
 @end

--- a/src/private/MDMBlockAnimations.h
+++ b/src/private/MDMBlockAnimations.h
@@ -18,7 +18,9 @@
 #import <QuartzCore/QuartzCore.h>
 
 @interface MDMImplicitAction: NSObject
-@property(nonatomic, strong, readonly) id initialValue;
+@property(nonatomic, strong, readonly) id initialModelValue;
+@property(nonatomic, readonly) BOOL hadPresentationLayer;
+@property(nonatomic, strong, readonly) id initialPresentationValue;
 @property(nonatomic, copy, readonly) NSString *keyPath;
 @property(nonatomic, strong, readonly) CALayer *layer;
 @end

--- a/tests/unit/BeginFromCurrentStateTests.swift
+++ b/tests/unit/BeginFromCurrentStateTests.swift
@@ -244,6 +244,6 @@ class BeginFromCurrentStateTests: XCTestCase {
     XCTAssertFalse(animation.isAdditive)
     XCTAssertEqual(animation.keyPath, AnimatableKeyPath.opacity.rawValue)
     XCTAssertEqual(animation.fromValue as! Float, initialValue)
-    XCTAssertEqual(animation.toValue as! CGFloat, 1.0)
+    XCTAssertEqualWithAccuracy(animation.toValue as! CGFloat, 1.0, accuracy: 0.0001)
   }
 }

--- a/tests/unit/BeginFromCurrentStateTests.swift
+++ b/tests/unit/BeginFromCurrentStateTests.swift
@@ -26,6 +26,7 @@ class BeginFromCurrentStateTests: XCTestCase {
   var animator: MotionAnimator!
   var timing: MotionTiming!
   var view: UIView!
+  var addedAnimations: [CAAnimation]!
 
   override func setUp() {
     super.setUp()
@@ -44,6 +45,11 @@ class BeginFromCurrentStateTests: XCTestCase {
     view = UIView() // Need to animate a view's layer to get implicit animations.
     window.addSubview(view)
 
+    addedAnimations = []
+    animator.addCoreAnimationTracer { (_, animation) in
+      self.addedAnimations.append(animation)
+    }
+
     // Connect our layers to the render server.
     CATransaction.flush()
   }
@@ -52,6 +58,7 @@ class BeginFromCurrentStateTests: XCTestCase {
     animator = nil
     timing = nil
     view = nil
+    addedAnimations = nil
 
     super.tearDown()
   }

--- a/tests/unit/BeginFromCurrentStateTests.swift
+++ b/tests/unit/BeginFromCurrentStateTests.swift
@@ -214,4 +214,29 @@ class BeginFromCurrentStateTests: XCTestCase {
     XCTAssertEqualWithAccuracy(view.layer.opacity, 0.2, accuracy: 0.0001,
                                "The layer's opacity was not set to the animation's final value.")
   }
+
+  func testViewAnimatesFromPresentationLayer() {
+    animator.beginFromCurrentState = true
+    animator.additive = false
+
+    animator.animate(with: timing) {
+      self.view.alpha = 0.5
+    }
+
+    RunLoop.main.run(until: .init(timeIntervalSinceNow: 0.01))
+
+    let initialValue = view.layer.presentation()!.opacity
+
+    animator.animate(with: timing) {
+      self.view.alpha = 1.0
+    }
+
+    XCTAssertEqual(addedAnimations.count, 2)
+
+    let animation = addedAnimations.last as! CABasicAnimation
+    XCTAssertFalse(animation.isAdditive)
+    XCTAssertEqual(animation.keyPath, AnimatableKeyPath.opacity.rawValue)
+    XCTAssertEqual(animation.fromValue as! Float, initialValue)
+    XCTAssertEqual(animation.toValue as! CGFloat, 1.0)
+  }
 }

--- a/tests/unit/ImplicitAnimationTests.swift
+++ b/tests/unit/ImplicitAnimationTests.swift
@@ -219,29 +219,4 @@ class ImplicitAnimationTests: XCTestCase {
                  "No animations should have been added, but the following keys were found: "
                   + "\(view.layer.animationKeys()!)")
   }
-
-  func testViewAnimatesFromPresentationLayer() {
-    animator.beginFromCurrentState = true
-    animator.additive = false
-
-    animator.animate(with: timing) {
-      self.view.alpha = 0.5
-    }
-
-    RunLoop.main.run(until: .init(timeIntervalSinceNow: 0.01))
-
-    let initialValue = view.layer.presentation()!.opacity
-
-    animator.animate(with: timing) {
-      self.view.alpha = 1.0
-    }
-
-    XCTAssertEqual(addedAnimations.count, 2)
-
-    let animation = addedAnimations.last as! CABasicAnimation
-    XCTAssertFalse(animation.isAdditive)
-    XCTAssertEqual(animation.keyPath, AnimatableKeyPath.opacity.rawValue)
-    XCTAssertEqual(animation.fromValue as! Float, initialValue)
-    XCTAssertEqual(animation.toValue as! CGFloat, 1.0)
-  }
 }

--- a/tests/unit/ImplicitAnimationTests.swift
+++ b/tests/unit/ImplicitAnimationTests.swift
@@ -219,4 +219,29 @@ class ImplicitAnimationTests: XCTestCase {
                  "No animations should have been added, but the following keys were found: "
                   + "\(view.layer.animationKeys()!)")
   }
+
+  func testViewAnimatesFromPresentationLayer() {
+    animator.beginFromCurrentState = true
+    animator.additive = false
+
+    animator.animate(with: timing) {
+      self.view.alpha = 0.5
+    }
+
+    RunLoop.main.run(until: .init(timeIntervalSinceNow: 0.01))
+
+    let initialValue = view.layer.presentation()!.opacity
+
+    animator.animate(with: timing) {
+      self.view.alpha = 1.0
+    }
+
+    XCTAssertEqual(addedAnimations.count, 2)
+
+    let animation = addedAnimations.last as! CABasicAnimation
+    XCTAssertFalse(animation.isAdditive)
+    XCTAssertEqual(animation.keyPath, AnimatableKeyPath.opacity.rawValue)
+    XCTAssertEqual(animation.fromValue as! Float, initialValue)
+    XCTAssertEqual(animation.toValue as! CGFloat, 1.0)
+  }
 }


### PR DESCRIPTION
Implicit animations are unable to read from the layer because the model layer has already changed by the time the animations get generated. This is problematic when beginFromCurrentState is enabled and the layer needs to extract its initial value.

Prior to this change, the implicit animation logic would attempt to read the same model layer value that had already been written, resulting in a no-op animation.

After this change, the implicit animation logic will cache the prior model/presentation layer values so that they can be used as the animation's initial values.