### PR TITLE
Run the implicit animations block when exiting early.

### DIFF
--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -125,6 +125,11 @@
   NSArray<MDMImplicitAction *> *actions = MDMAnimateImplicitly(animations);
 
   void (^exitEarly)(void) = ^{
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    animations();
+    [CATransaction commit];
+
     if (completion) {
       completion();
     }

--- a/tests/unit/ImplicitAnimationTests.swift
+++ b/tests/unit/ImplicitAnimationTests.swift
@@ -210,6 +210,28 @@ class ImplicitAnimationTests: XCTestCase {
     XCTAssertEqual(view.layer.animationKeys()!, ["opacity"])
   }
 
+  func testDurationOfZeroRunsAnimationsBlockButGeneratesNoAnimations() {
+    timing.duration = 0
+
+    animator.animate(with: timing) {
+      self.view.alpha = 0
+    }
+
+    XCTAssertEqual(addedAnimations.count, 0)
+    XCTAssertEqual(view.alpha, 0)
+  }
+
+  func testTimeScaleFactorOfZeroRunsAnimationsBlockButGeneratesNoAnimations() {
+    animator.timeScaleFactor = 0
+
+    animator.animate(with: timing) {
+      self.view.alpha = 0
+    }
+
+    XCTAssertEqual(addedAnimations.count, 0)
+    XCTAssertEqual(view.alpha, 0)
+  }
+
   func testUnsupportedAnimationKeyIsNotAnimated() {
     animator.animate(with: timing) {
       self.view.layer.sublayers = []


### PR DESCRIPTION
This ensures that the animation values are still set to their desired destination.

Also added a test to catch regressions.