### PR TITLE
Migrate to the Objective-C interchange format

### DIFF
--- a/MotionAnimator.podspec
+++ b/MotionAnimator.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.public_header_files = "src/*.h"
   s.source_files = "src/*.{h,m,mm}", "src/private/*.{h,m,mm}"
 
-  s.dependency "MotionInterchange", "~> 1.3"
+  s.dependency "MotionInterchange", "~> 1.6"
 end

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,6 @@ target "MotionAnimatorCatalog" do
   pod 'CatalogByConvention'
   pod 'MotionAnimator', :path => './'
   project 'examples/apps/Catalog/MotionAnimatorCatalog.xcodeproj'
-  pod 'MotionInterchange', :path => '../motion-interchange-objc/'
 end
 
 target "UnitTests" do

--- a/Podfile
+++ b/Podfile
@@ -5,6 +5,7 @@ target "MotionAnimatorCatalog" do
   pod 'CatalogByConvention'
   pod 'MotionAnimator', :path => './'
   project 'examples/apps/Catalog/MotionAnimatorCatalog.xcodeproj'
+  pod 'MotionInterchange', :path => '../motion-interchange-objc/'
 end
 
 target "UnitTests" do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,21 +2,24 @@ PODS:
   - CatalogByConvention (2.2.0)
   - MotionAnimator (2.6.0):
     - MotionInterchange (~> 1.3)
-  - MotionInterchange (1.3.0)
+  - MotionInterchange (1.6.0)
 
 DEPENDENCIES:
   - CatalogByConvention
   - MotionAnimator (from `./`)
+  - MotionInterchange (from `../motion-interchange-objc/`)
 
 EXTERNAL SOURCES:
   MotionAnimator:
     :path: ./
+  MotionInterchange:
+    :path: ../motion-interchange-objc/
 
 SPEC CHECKSUMS:
   CatalogByConvention: 5df5831e48b8083b18570dcb804f20fd1c90694f
   MotionAnimator: a4b0ba87a674bb3e89e25f0530b7e80a204ac1c1
-  MotionInterchange: 988fc0011e4b806cc33f2fb4f9566f5eeb4159e8
+  MotionInterchange: ead0e3ae1f3a5fb539e289debbc7ae036160a10d
 
-PODFILE CHECKSUM: 3537bf01c11174928ac008c20fec4738722e96f3
+PODFILE CHECKSUM: f354f45cd3f9eb0e6ac9a2bfd9429945eae8c0ad
 
 COCOAPODS: 1.3.1

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,5 +27,5 @@ git_repository(
 git_repository(
     name = "motion_interchange_objc",
     remote = "https://github.com/material-motion/motion-interchange-objc.git",
-    tag = "v1.3.0",
+    tag = "v1.6.0",
 )

--- a/examples/CalendarCardExpansionExample.m
+++ b/examples/CalendarCardExpansionExample.m
@@ -56,36 +56,26 @@
   CGRect headerFrame = [self frameForHeader];
 
   // Animate the chip itself.
-  [animator animateWithTraits:traits.chipHeight
-                       values:@[ @(chipFrame.size.height), @(headerFrame.size.height) ]
-                        layer:_chipView.layer
-                      keyPath:MDMKeyPathHeight];
-  [animator animateWithTraits:traits.chipWidth
-                       values:@[ @(chipFrame.size.width), @(headerFrame.size.width) ]
-                        layer:_chipView.layer
-                      keyPath:MDMKeyPathWidth];
-  [animator animateWithTraits:traits.chipWidth
-                       values:@[ @(CGRectGetMidX(chipFrame)), @(CGRectGetMidX(headerFrame)) ]
-                        layer:_chipView.layer
-                      keyPath:MDMKeyPathX];
-  [animator animateWithTraits:traits.chipY
-                       values:@[ @(CGRectGetMidY(chipFrame)), @(CGRectGetMidY(headerFrame)) ]
-                        layer:_chipView.layer
-                      keyPath:MDMKeyPathY];
-  [animator animateWithTraits:traits.chipHeight
-                       values:@[ @([self chipCornerRadius]), @0 ]
-                        layer:_chipView.layer
-                      keyPath:MDMKeyPathCornerRadius];
+  [animator animateWithTraits:traits.chipHeight values:@[ @(chipFrame.size.height),
+                                                          @(headerFrame.size.height) ]
+                        layer:_chipView.layer keyPath:MDMKeyPathHeight];
+  [animator animateWithTraits:traits.chipWidth values:@[ @(chipFrame.size.width),
+                                                         @(headerFrame.size.width) ]
+                        layer:_chipView.layer keyPath:MDMKeyPathWidth];
+  [animator animateWithTraits:traits.chipWidth values:@[ @(CGRectGetMidX(chipFrame)),
+                                                         @(CGRectGetMidX(headerFrame)) ]
+                        layer:_chipView.layer keyPath:MDMKeyPathX];
+  [animator animateWithTraits:traits.chipY values:@[ @(CGRectGetMidY(chipFrame)),
+                                                     @(CGRectGetMidY(headerFrame)) ]
+                        layer:_chipView.layer keyPath:MDMKeyPathY];
+  [animator animateWithTraits:traits.chipHeight values:@[ @([self chipCornerRadius]), @0 ]
+                        layer:_chipView.layer keyPath:MDMKeyPathCornerRadius];
 
   // Cross-fade the chip's contents.
-  [animator animateWithTraits:traits.chipContentOpacity
-                       values:@[ @1, @0 ]
-                        layer:_collapsedContent.layer
-                      keyPath:MDMKeyPathOpacity];
-  [animator animateWithTraits:traits.headerContentOpacity
-                       values:@[ @0, @1 ]
-                        layer:_expandedContent.layer
-                      keyPath:MDMKeyPathOpacity];
+  [animator animateWithTraits:traits.chipContentOpacity values:@[ @1, @0 ]
+                        layer:_collapsedContent.layer keyPath:MDMKeyPathOpacity];
+  [animator animateWithTraits:traits.headerContentOpacity values:@[ @0, @1 ]
+                        layer:_expandedContent.layer keyPath:MDMKeyPathOpacity];
 
   // Keeps the expandec content aligned to the bottom of the card by taking into consideration the
   // extra height.
@@ -93,8 +83,7 @@
   [animator animateWithTraits:traits.chipHeight
                        values:@[ @(CGRectGetMidY([self expandedContentFrame]) + excessTopMargin),
                                  @(CGRectGetMidY([self expandedContentFrame])) ]
-                        layer:_expandedContent.layer
-                      keyPath:MDMKeyPathY];
+                        layer:_expandedContent.layer keyPath:MDMKeyPathY];
 
   // Keeps the collapsed content aligned to its position on screen by taking into consideration the
   // excess left margin.
@@ -102,20 +91,17 @@
   [animator animateWithTraits:traits.chipWidth
                        values:@[ @(CGRectGetMidX([self collapsedContentFrame])),
                                  @(CGRectGetMidX([self collapsedContentFrame]) + excessLeftMargin) ]
-                        layer:_collapsedContent.layer
-                      keyPath:MDMKeyPathX];
+                        layer:_collapsedContent.layer keyPath:MDMKeyPathX];
 
   // Keeps the shape anchored to the bottom right of the chip.
   CGRect shapeFrameInChip = [self shapeFrameInRect:chipFrame];
   CGRect shapeFrameInHeader = [self shapeFrameInRect:headerFrame];
-  [animator animateWithTraits:traits.chipWidth
-                       values:@[ @(CGRectGetMidX(shapeFrameInChip)), @(CGRectGetMidX(shapeFrameInHeader)) ]
-                        layer:_shapeView.layer
-                      keyPath:MDMKeyPathX];
-  [animator animateWithTraits:traits.chipHeight
-                       values:@[ @(CGRectGetMidY(shapeFrameInChip)), @(CGRectGetMidY(shapeFrameInHeader)) ]
-                        layer:_shapeView.layer
-                      keyPath:MDMKeyPathY];
+  [animator animateWithTraits:traits.chipWidth values:@[ @(CGRectGetMidX(shapeFrameInChip)),
+                                                         @(CGRectGetMidX(shapeFrameInHeader)) ]
+                        layer:_shapeView.layer keyPath:MDMKeyPathX];
+  [animator animateWithTraits:traits.chipHeight values:@[ @(CGRectGetMidY(shapeFrameInChip)),
+                                                          @(CGRectGetMidY(shapeFrameInHeader)) ]
+                        layer:_shapeView.layer keyPath:MDMKeyPathY];
 }
 
 #pragma mark - View creation and initial layout

--- a/examples/CalendarCardExpansionExample.m
+++ b/examples/CalendarCardExpansionExample.m
@@ -20,12 +20,12 @@
 
 #import "MotionAnimator.h"
 
-// This example demonstrates how to use a motion timing specification to build a complex
+// This example demonstrates how to use a motion traits specification to build a complex
 // bi-directional animation using the MDMMotionAnimator object. MDMMotionAnimator is designed for
 // building fine-tuned explicit animations. Unlike UIView's implicit animation API, which can be
 // used to cause cascading animations on a variety of properties, MDMMotionAnimator will always add
 // exactly one animation per key path to the layer. This means you don't get as much for "free", but
-// you do gain more control over the timing and motion of the animation.
+// you do gain more control over the traits and motion of the animation.
 
 @implementation CalendarCardExpansionExampleViewController {
   // In a real-world scenario we'd likely create a separate view to manage all of these subviews so
@@ -40,15 +40,15 @@
 - (void)didTap {
   _expanded = !_expanded;
 
-  CalendarChipTiming timing = (_expanded
-                               ? CalendarChipMotionSpec.expansion
-                               : CalendarChipMotionSpec.collapse);
+  id<CalendarChipTiming> traits = (_expanded
+                                   ? CalendarChipMotionSpec.expansion
+                                   : CalendarChipMotionSpec.collapse);
 
   MDMMotionAnimator *animator = [[MDMMotionAnimator alloc] init];
   animator.shouldReverseValues = !_expanded;
   animator.beginFromCurrentState = YES;
 
-  [animator animateWithTiming:timing.navigationBarY animations:^{
+  [animator animateWithTraits:traits.navigationBarY animations:^{
     [self.navigationController setNavigationBarHidden:_expanded animated:YES];
   }];
 
@@ -56,65 +56,65 @@
   CGRect headerFrame = [self frameForHeader];
 
   // Animate the chip itself.
-  [animator animateWithTiming:timing.chipHeight
-                      toLayer:_chipView.layer
-                   withValues:@[ @(chipFrame.size.height), @(headerFrame.size.height) ]
+  [animator animateWithTraits:traits.chipHeight
+                       values:@[ @(chipFrame.size.height), @(headerFrame.size.height) ]
+                        layer:_chipView.layer
                       keyPath:MDMKeyPathHeight];
-  [animator animateWithTiming:timing.chipWidth
-                      toLayer:_chipView.layer
-                   withValues:@[ @(chipFrame.size.width), @(headerFrame.size.width) ]
+  [animator animateWithTraits:traits.chipWidth
+                       values:@[ @(chipFrame.size.width), @(headerFrame.size.width) ]
+                        layer:_chipView.layer
                       keyPath:MDMKeyPathWidth];
-  [animator animateWithTiming:timing.chipWidth
-                      toLayer:_chipView.layer
-                   withValues:@[ @(CGRectGetMidX(chipFrame)), @(CGRectGetMidX(headerFrame)) ]
+  [animator animateWithTraits:traits.chipWidth
+                       values:@[ @(CGRectGetMidX(chipFrame)), @(CGRectGetMidX(headerFrame)) ]
+                        layer:_chipView.layer
                       keyPath:MDMKeyPathX];
-  [animator animateWithTiming:timing.chipY
-                      toLayer:_chipView.layer
-                   withValues:@[ @(CGRectGetMidY(chipFrame)), @(CGRectGetMidY(headerFrame)) ]
+  [animator animateWithTraits:traits.chipY
+                       values:@[ @(CGRectGetMidY(chipFrame)), @(CGRectGetMidY(headerFrame)) ]
+                        layer:_chipView.layer
                       keyPath:MDMKeyPathY];
-  [animator animateWithTiming:timing.chipHeight
-                      toLayer:_chipView.layer
-                   withValues:@[ @([self chipCornerRadius]), @0 ]
+  [animator animateWithTraits:traits.chipHeight
+                       values:@[ @([self chipCornerRadius]), @0 ]
+                        layer:_chipView.layer
                       keyPath:MDMKeyPathCornerRadius];
 
   // Cross-fade the chip's contents.
-  [animator animateWithTiming:timing.chipContentOpacity
-                      toLayer:_collapsedContent.layer
-                   withValues:@[ @1, @0 ]
+  [animator animateWithTraits:traits.chipContentOpacity
+                       values:@[ @1, @0 ]
+                        layer:_collapsedContent.layer
                       keyPath:MDMKeyPathOpacity];
-  [animator animateWithTiming:timing.headerContentOpacity
-                      toLayer:_expandedContent.layer
-                   withValues:@[ @0, @1 ]
+  [animator animateWithTraits:traits.headerContentOpacity
+                       values:@[ @0, @1 ]
+                        layer:_expandedContent.layer
                       keyPath:MDMKeyPathOpacity];
 
   // Keeps the expandec content aligned to the bottom of the card by taking into consideration the
   // extra height.
   CGFloat excessTopMargin = chipFrame.size.height - headerFrame.size.height;
-  [animator animateWithTiming:timing.chipHeight
-                      toLayer:_expandedContent.layer
-                   withValues:@[ @(CGRectGetMidY([self expandedContentFrame]) + excessTopMargin),
+  [animator animateWithTraits:traits.chipHeight
+                       values:@[ @(CGRectGetMidY([self expandedContentFrame]) + excessTopMargin),
                                  @(CGRectGetMidY([self expandedContentFrame])) ]
+                        layer:_expandedContent.layer
                       keyPath:MDMKeyPathY];
 
   // Keeps the collapsed content aligned to its position on screen by taking into consideration the
   // excess left margin.
   CGFloat excessLeftMargin = chipFrame.origin.x - headerFrame.origin.x;
-  [animator animateWithTiming:timing.chipWidth
-                      toLayer:_collapsedContent.layer
-                   withValues:@[ @(CGRectGetMidX([self collapsedContentFrame])),
+  [animator animateWithTraits:traits.chipWidth
+                       values:@[ @(CGRectGetMidX([self collapsedContentFrame])),
                                  @(CGRectGetMidX([self collapsedContentFrame]) + excessLeftMargin) ]
+                        layer:_collapsedContent.layer
                       keyPath:MDMKeyPathX];
 
   // Keeps the shape anchored to the bottom right of the chip.
   CGRect shapeFrameInChip = [self shapeFrameInRect:chipFrame];
   CGRect shapeFrameInHeader = [self shapeFrameInRect:headerFrame];
-  [animator animateWithTiming:timing.chipWidth
-                      toLayer:_shapeView.layer
-                   withValues:@[ @(CGRectGetMidX(shapeFrameInChip)), @(CGRectGetMidX(shapeFrameInHeader)) ]
+  [animator animateWithTraits:traits.chipWidth
+                       values:@[ @(CGRectGetMidX(shapeFrameInChip)), @(CGRectGetMidX(shapeFrameInHeader)) ]
+                        layer:_shapeView.layer
                       keyPath:MDMKeyPathX];
-  [animator animateWithTiming:timing.chipHeight
-                      toLayer:_shapeView.layer
-                   withValues:@[ @(CGRectGetMidY(shapeFrameInChip)), @(CGRectGetMidY(shapeFrameInHeader)) ]
+  [animator animateWithTraits:traits.chipHeight
+                       values:@[ @(CGRectGetMidY(shapeFrameInChip)), @(CGRectGetMidY(shapeFrameInHeader)) ]
+                        layer:_shapeView.layer
                       keyPath:MDMKeyPathY];
 }
 

--- a/examples/CalendarCardExpansionExample.m
+++ b/examples/CalendarCardExpansionExample.m
@@ -56,26 +56,36 @@
   CGRect headerFrame = [self frameForHeader];
 
   // Animate the chip itself.
-  [animator animateWithTraits:traits.chipHeight between:@[ @(chipFrame.size.height),
-                                                           @(headerFrame.size.height) ]
-                        layer:_chipView.layer keyPath:MDMKeyPathHeight];
-  [animator animateWithTraits:traits.chipWidth between:@[ @(chipFrame.size.width),
-                                                          @(headerFrame.size.width) ]
-                        layer:_chipView.layer keyPath:MDMKeyPathWidth];
-  [animator animateWithTraits:traits.chipWidth between:@[ @(CGRectGetMidX(chipFrame)),
-                                                          @(CGRectGetMidX(headerFrame)) ]
-                        layer:_chipView.layer keyPath:MDMKeyPathX];
-  [animator animateWithTraits:traits.chipY between:@[ @(CGRectGetMidY(chipFrame)),
-                                                      @(CGRectGetMidY(headerFrame)) ]
-                        layer:_chipView.layer keyPath:MDMKeyPathY];
-  [animator animateWithTraits:traits.chipHeight between:@[ @([self chipCornerRadius]), @0 ]
-                        layer:_chipView.layer keyPath:MDMKeyPathCornerRadius];
+  [animator animateWithTraits:traits.chipHeight
+                      between:@[ @(chipFrame.size.height), @(headerFrame.size.height) ]
+                        layer:_chipView.layer
+                      keyPath:MDMKeyPathHeight];
+  [animator animateWithTraits:traits.chipWidth
+                      between:@[ @(chipFrame.size.width), @(headerFrame.size.width) ]
+                        layer:_chipView.layer
+                      keyPath:MDMKeyPathWidth];
+  [animator animateWithTraits:traits.chipWidth
+                      between:@[ @(CGRectGetMidX(chipFrame)), @(CGRectGetMidX(headerFrame)) ]
+                        layer:_chipView.layer
+                      keyPath:MDMKeyPathX];
+  [animator animateWithTraits:traits.chipY
+                      between:@[ @(CGRectGetMidY(chipFrame)), @(CGRectGetMidY(headerFrame)) ]
+                        layer:_chipView.layer
+                      keyPath:MDMKeyPathY];
+  [animator animateWithTraits:traits.chipHeight
+                      between:@[ @([self chipCornerRadius]), @0 ]
+                        layer:_chipView.layer
+                      keyPath:MDMKeyPathCornerRadius];
 
   // Cross-fade the chip's contents.
-  [animator animateWithTraits:traits.chipContentOpacity between:@[ @1, @0 ]
-                        layer:_collapsedContent.layer keyPath:MDMKeyPathOpacity];
-  [animator animateWithTraits:traits.headerContentOpacity between:@[ @0, @1 ]
-                        layer:_expandedContent.layer keyPath:MDMKeyPathOpacity];
+  [animator animateWithTraits:traits.chipContentOpacity
+                      between:@[ @1, @0 ]
+                        layer:_collapsedContent.layer
+                      keyPath:MDMKeyPathOpacity];
+  [animator animateWithTraits:traits.headerContentOpacity
+                      between:@[ @0, @1 ]
+                        layer:_expandedContent.layer
+                      keyPath:MDMKeyPathOpacity];
 
   // Keeps the expandec content aligned to the bottom of the card by taking into consideration the
   // extra height.
@@ -83,7 +93,8 @@
   [animator animateWithTraits:traits.chipHeight
                       between:@[ @(CGRectGetMidY([self expandedContentFrame]) + excessTopMargin),
                                  @(CGRectGetMidY([self expandedContentFrame])) ]
-                        layer:_expandedContent.layer keyPath:MDMKeyPathY];
+                        layer:_expandedContent.layer
+                      keyPath:MDMKeyPathY];
 
   // Keeps the collapsed content aligned to its position on screen by taking into consideration the
   // excess left margin.
@@ -91,17 +102,22 @@
   [animator animateWithTraits:traits.chipWidth
                       between:@[ @(CGRectGetMidX([self collapsedContentFrame])),
                                  @(CGRectGetMidX([self collapsedContentFrame]) + excessLeftMargin) ]
-                        layer:_collapsedContent.layer keyPath:MDMKeyPathX];
+                        layer:_collapsedContent.layer
+                      keyPath:MDMKeyPathX];
 
   // Keeps the shape anchored to the bottom right of the chip.
   CGRect shapeFrameInChip = [self shapeFrameInRect:chipFrame];
   CGRect shapeFrameInHeader = [self shapeFrameInRect:headerFrame];
-  [animator animateWithTraits:traits.chipWidth between:@[ @(CGRectGetMidX(shapeFrameInChip)),
-                                                          @(CGRectGetMidX(shapeFrameInHeader)) ]
-                        layer:_shapeView.layer keyPath:MDMKeyPathX];
-  [animator animateWithTraits:traits.chipHeight between:@[ @(CGRectGetMidY(shapeFrameInChip)),
-                                                           @(CGRectGetMidY(shapeFrameInHeader)) ]
-                        layer:_shapeView.layer keyPath:MDMKeyPathY];
+  [animator animateWithTraits:traits.chipWidth
+                      between:@[ @(CGRectGetMidX(shapeFrameInChip)),
+                                 @(CGRectGetMidX(shapeFrameInHeader)) ]
+                        layer:_shapeView.layer
+                      keyPath:MDMKeyPathX];
+  [animator animateWithTraits:traits.chipHeight
+                      between:@[ @(CGRectGetMidY(shapeFrameInChip)),
+                                 @(CGRectGetMidY(shapeFrameInHeader)) ]
+                        layer:_shapeView.layer
+                      keyPath:MDMKeyPathY];
 }
 
 #pragma mark - View creation and initial layout

--- a/examples/CalendarCardExpansionExample.m
+++ b/examples/CalendarCardExpansionExample.m
@@ -56,32 +56,32 @@
   CGRect headerFrame = [self frameForHeader];
 
   // Animate the chip itself.
-  [animator animateWithTraits:traits.chipHeight values:@[ @(chipFrame.size.height),
-                                                          @(headerFrame.size.height) ]
+  [animator animateWithTraits:traits.chipHeight between:@[ @(chipFrame.size.height),
+                                                           @(headerFrame.size.height) ]
                         layer:_chipView.layer keyPath:MDMKeyPathHeight];
-  [animator animateWithTraits:traits.chipWidth values:@[ @(chipFrame.size.width),
-                                                         @(headerFrame.size.width) ]
+  [animator animateWithTraits:traits.chipWidth between:@[ @(chipFrame.size.width),
+                                                          @(headerFrame.size.width) ]
                         layer:_chipView.layer keyPath:MDMKeyPathWidth];
-  [animator animateWithTraits:traits.chipWidth values:@[ @(CGRectGetMidX(chipFrame)),
-                                                         @(CGRectGetMidX(headerFrame)) ]
+  [animator animateWithTraits:traits.chipWidth between:@[ @(CGRectGetMidX(chipFrame)),
+                                                          @(CGRectGetMidX(headerFrame)) ]
                         layer:_chipView.layer keyPath:MDMKeyPathX];
-  [animator animateWithTraits:traits.chipY values:@[ @(CGRectGetMidY(chipFrame)),
-                                                     @(CGRectGetMidY(headerFrame)) ]
+  [animator animateWithTraits:traits.chipY between:@[ @(CGRectGetMidY(chipFrame)),
+                                                      @(CGRectGetMidY(headerFrame)) ]
                         layer:_chipView.layer keyPath:MDMKeyPathY];
-  [animator animateWithTraits:traits.chipHeight values:@[ @([self chipCornerRadius]), @0 ]
+  [animator animateWithTraits:traits.chipHeight between:@[ @([self chipCornerRadius]), @0 ]
                         layer:_chipView.layer keyPath:MDMKeyPathCornerRadius];
 
   // Cross-fade the chip's contents.
-  [animator animateWithTraits:traits.chipContentOpacity values:@[ @1, @0 ]
+  [animator animateWithTraits:traits.chipContentOpacity between:@[ @1, @0 ]
                         layer:_collapsedContent.layer keyPath:MDMKeyPathOpacity];
-  [animator animateWithTraits:traits.headerContentOpacity values:@[ @0, @1 ]
+  [animator animateWithTraits:traits.headerContentOpacity between:@[ @0, @1 ]
                         layer:_expandedContent.layer keyPath:MDMKeyPathOpacity];
 
   // Keeps the expandec content aligned to the bottom of the card by taking into consideration the
   // extra height.
   CGFloat excessTopMargin = chipFrame.size.height - headerFrame.size.height;
   [animator animateWithTraits:traits.chipHeight
-                       values:@[ @(CGRectGetMidY([self expandedContentFrame]) + excessTopMargin),
+                      between:@[ @(CGRectGetMidY([self expandedContentFrame]) + excessTopMargin),
                                  @(CGRectGetMidY([self expandedContentFrame])) ]
                         layer:_expandedContent.layer keyPath:MDMKeyPathY];
 
@@ -89,18 +89,18 @@
   // excess left margin.
   CGFloat excessLeftMargin = chipFrame.origin.x - headerFrame.origin.x;
   [animator animateWithTraits:traits.chipWidth
-                       values:@[ @(CGRectGetMidX([self collapsedContentFrame])),
+                      between:@[ @(CGRectGetMidX([self collapsedContentFrame])),
                                  @(CGRectGetMidX([self collapsedContentFrame]) + excessLeftMargin) ]
                         layer:_collapsedContent.layer keyPath:MDMKeyPathX];
 
   // Keeps the shape anchored to the bottom right of the chip.
   CGRect shapeFrameInChip = [self shapeFrameInRect:chipFrame];
   CGRect shapeFrameInHeader = [self shapeFrameInRect:headerFrame];
-  [animator animateWithTraits:traits.chipWidth values:@[ @(CGRectGetMidX(shapeFrameInChip)),
-                                                         @(CGRectGetMidX(shapeFrameInHeader)) ]
+  [animator animateWithTraits:traits.chipWidth between:@[ @(CGRectGetMidX(shapeFrameInChip)),
+                                                          @(CGRectGetMidX(shapeFrameInHeader)) ]
                         layer:_shapeView.layer keyPath:MDMKeyPathX];
-  [animator animateWithTraits:traits.chipHeight values:@[ @(CGRectGetMidY(shapeFrameInChip)),
-                                                          @(CGRectGetMidY(shapeFrameInHeader)) ]
+  [animator animateWithTraits:traits.chipHeight between:@[ @(CGRectGetMidY(shapeFrameInChip)),
+                                                           @(CGRectGetMidY(shapeFrameInHeader)) ]
                         layer:_shapeView.layer keyPath:MDMKeyPathY];
 }
 

--- a/examples/CalendarChipMotionSpec.h
+++ b/examples/CalendarChipMotionSpec.h
@@ -17,24 +17,26 @@
 #import <Foundation/Foundation.h>
 #import <MotionInterchange/MotionInterchange.h>
 
-typedef struct CalendarChipTiming {
-  MDMMotionTiming chipWidth;
-  MDMMotionTiming chipHeight;
-  MDMMotionTiming chipY;
+@protocol CalendarChipTiming <NSObject>
 
-  MDMMotionTiming chipContentOpacity;
-  MDMMotionTiming headerContentOpacity;
+@property(nonatomic, strong, nonnull, readonly) MDMAnimationTraits *chipWidth;
+@property(nonatomic, strong, nonnull, readonly) MDMAnimationTraits *chipHeight;
+@property(nonatomic, strong, nonnull, readonly) MDMAnimationTraits *chipY;
 
-  MDMMotionTiming navigationBarY;
-} CalendarChipTiming;
+@property(nonatomic, strong, nonnull, readonly) MDMAnimationTraits *chipContentOpacity;
+@property(nonatomic, strong, nonnull, readonly) MDMAnimationTraits *headerContentOpacity;
+
+@property(nonatomic, strong, nonnull, readonly) MDMAnimationTraits *navigationBarY;
+
+@end
 
 @interface CalendarChipMotionSpec: NSObject
 
-@property(nonatomic, class, readonly) CalendarChipTiming expansion;
-@property(nonatomic, class, readonly) CalendarChipTiming collapse;
+@property(nonatomic, class, strong, nonnull, readonly) id<CalendarChipTiming> expansion;
+@property(nonatomic, class, strong, nonnull, readonly) id<CalendarChipTiming> collapse;
 
 // This object is not meant to be instantiated.
-- (instancetype)init NS_UNAVAILABLE;
+- (nonnull instancetype)init NS_UNAVAILABLE;
 
 @end
 

--- a/examples/CalendarChipMotionSpec.m
+++ b/examples/CalendarChipMotionSpec.m
@@ -16,58 +16,84 @@
 
 #import "CalendarChipMotionSpec.h"
 
+static id<MDMTimingCurve> StandardTimingCurve(void) {
+  return [CAMediaTimingFunction functionWithControlPoints:0.4f :0.0f :0.2f :1.0f];
+}
+
+static id<MDMTimingCurve> LinearTimingCurve(void) {
+  return [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
+}
+
+@interface CalendarChipExpansionTiming: NSObject <CalendarChipTiming>
+@end
+
+@implementation CalendarChipExpansionTiming
+
+- (MDMAnimationTraits *)chipWidth {
+  return [[MDMAnimationTraits alloc] initWithDelay:0.000 duration:0.285 timingCurve:StandardTimingCurve()];
+}
+
+- (MDMAnimationTraits *)chipHeight {
+  return [[MDMAnimationTraits alloc] initWithDelay:0.015 duration:0.360 timingCurve:StandardTimingCurve()];
+}
+
+- (MDMAnimationTraits *)chipY {
+  return [[MDMAnimationTraits alloc] initWithDelay:0.015 duration:0.360 timingCurve:StandardTimingCurve()];
+}
+
+- (MDMAnimationTraits *)chipContentOpacity {
+  return [[MDMAnimationTraits alloc] initWithDelay:0.000 duration:0.075 timingCurve:LinearTimingCurve()];
+}
+
+- (MDMAnimationTraits *)headerContentOpacity {
+  return [[MDMAnimationTraits alloc] initWithDelay:0.075 duration:0.150 timingCurve:LinearTimingCurve()];
+}
+
+- (MDMAnimationTraits *)navigationBarY {
+  return [[MDMAnimationTraits alloc] initWithDelay:0.015 duration:0.360 timingCurve:StandardTimingCurve()];
+}
+
+@end
+
+@interface CalendarChipCollapseTiming: NSObject <CalendarChipTiming>
+@end
+
+@implementation CalendarChipCollapseTiming
+
+- (MDMAnimationTraits *)chipWidth {
+  return [[MDMAnimationTraits alloc] initWithDelay:0.045 duration:0.330 timingCurve:StandardTimingCurve()];
+}
+
+- (MDMAnimationTraits *)chipHeight {
+  return [[MDMAnimationTraits alloc] initWithDelay:0.000 duration:0.330 timingCurve:StandardTimingCurve()];
+}
+
+- (MDMAnimationTraits *)chipY {
+  return [[MDMAnimationTraits alloc] initWithDelay:0.015 duration:0.330 timingCurve:StandardTimingCurve()];
+}
+
+- (MDMAnimationTraits *)chipContentOpacity {
+  return [[MDMAnimationTraits alloc] initWithDelay:0.150 duration:0.150 timingCurve:LinearTimingCurve()];
+}
+
+- (MDMAnimationTraits *)headerContentOpacity {
+  return [[MDMAnimationTraits alloc] initWithDelay:0.000 duration:0.075 timingCurve:LinearTimingCurve()];
+}
+
+- (MDMAnimationTraits *)navigationBarY {
+  return [[MDMAnimationTraits alloc] initWithDelay:0.045 duration:0.150 timingCurve:StandardTimingCurve()];
+}
+
+@end
+
 @implementation CalendarChipMotionSpec
 
-+ (MDMMotionCurve)eightyForty {
-  return MDMMotionCurveMakeBezier(0.4f, 0.0f, 0.2f, 1.0f);
++ (id<CalendarChipTiming>)expansion {
+  return [[CalendarChipExpansionTiming alloc] init];
 }
 
-+ (CalendarChipTiming)expansion {
-  MDMMotionCurve eightyForty = [self eightyForty];
-  return (CalendarChipTiming){
-    .chipWidth = {
-      .delay = 0.000, .duration = 0.285, .curve = eightyForty,
-    },
-    .chipHeight = {
-      .delay = 0.015, .duration = 0.360, .curve = eightyForty,
-    },
-    .chipY = {
-      .delay = 0.015, .duration = 0.360, .curve = eightyForty,
-    },
-    .chipContentOpacity = {
-      .delay = 0.000, .duration = 0.075, .curve = MDMLinearMotionCurve,
-    },
-    .headerContentOpacity = {
-      .delay = 0.075, .duration = 0.150, .curve = MDMLinearMotionCurve,
-    },
-    .navigationBarY = {
-      .delay = 0.015, .duration = 0.360, .curve = eightyForty,
-    },
-  };
-}
-
-+ (CalendarChipTiming)collapse {
-  MDMMotionCurve eightyForty = [self eightyForty];
-  return (CalendarChipTiming){
-    .chipWidth = {
-      .delay = 0.045, .duration = 0.330, .curve = eightyForty,
-    },
-    .chipHeight = {
-      .delay = 0.000, .duration = 0.330, .curve = eightyForty,
-    },
-    .chipY = {
-      .delay = 0.015, .duration = 0.330, .curve = eightyForty,
-    },
-    .chipContentOpacity = {
-      .delay = 0.150, .duration = 0.150, .curve = MDMLinearMotionCurve,
-    },
-    .headerContentOpacity = {
-      .delay = 0.000, .duration = 0.075, .curve = MDMLinearMotionCurve,
-    },
-    .navigationBarY = {
-      .delay = 0.045, .duration = 0.150, .curve = eightyForty,
-    }
-  };
++ (id<CalendarChipTiming>)collapse {
+  return [[CalendarChipCollapseTiming alloc] init];
 }
 
 @end

--- a/examples/TapToBounceExample.swift
+++ b/examples/TapToBounceExample.swift
@@ -40,21 +40,22 @@ class TapToBounceExampleViewController: UIViewController {
                      for: [.touchUpInside, .touchUpOutside, .touchDragExit])
   }
 
-  let timing = MotionTiming(delay: 0,
-                            duration: 0.5,
-                            curve: MotionCurveMakeSpring(mass: 1, tension: 100, friction: 10),
-                            repetition: .init())
+  let traits = MDMAnimationTraits(delay: 0,
+                                  duration: 0.5,
+                                  timingCurve: MDMSpringTimingCurve(mass: 1,
+                                                                    tension: 100,
+                                                                    friction: 10))
 
   func didFocus(_ sender: UIButton) {
     let animator = MotionAnimator()
-    animator.animate(with: timing) {
+    animator.animate(with: traits) {
       sender.transform = CGAffineTransform(scaleX: 1.5, y: 1.5)
     }
   }
 
   func didUnfocus(_ sender: UIButton) {
     let animator = MotionAnimator()
-    animator.animate(with: timing) {
+    animator.animate(with: traits) {
       sender.transform = .identity
     }
   }

--- a/src/MDMMotionAnimator.h
+++ b/src/MDMMotionAnimator.h
@@ -27,7 +27,7 @@
 #import "MDMCoreAnimationTraceable.h"
 
 /**
- An animator adds Core Animation animations to a layer based on a provided motion traits.
+ An animator adds Core Animation animations to a layer using animation traits.
  */
 NS_SWIFT_NAME(MotionAnimator)
 @interface MDMMotionAnimator : NSObject <MDMCoreAnimationTraceable>

--- a/src/MDMMotionAnimator.h
+++ b/src/MDMMotionAnimator.h
@@ -27,7 +27,7 @@
 #import "MDMCoreAnimationTraceable.h"
 
 /**
- An animator adds Core Animation animations to a layer based on a provided motion timing.
+ An animator adds Core Animation animations to a layer based on a provided motion traits.
  */
 NS_SWIFT_NAME(MotionAnimator)
 @interface MDMMotionAnimator : NSObject <MDMCoreAnimationTraceable>
@@ -44,7 +44,7 @@ NS_SWIFT_NAME(MotionAnimator)
 /**
  If enabled, explicitly-provided values will be reversed before animating.
 
- This property does not affect the animateWithTiming:animations: family of methods.
+ This property does not affect the animateWithTraits:animations: family of methods.
 
  Disabled by default.
  */
@@ -70,32 +70,32 @@ NS_SWIFT_NAME(MotionAnimator)
 @property(nonatomic, assign) BOOL additive;
 
 /**
- Adds a single animation to the layer with the given timing structure.
+ Adds a single animation to the layer with the given traits structure.
 
  If `additive` is disabled, the animation will be added to the layer with the keyPath as its key.
  In this case, multiple invocations of this function on the same key path will remove the
  animations added from prior invocations.
 
- @param timing The timing to be used for the animation.
+ @param traits The traits to be used for the animation.
  @param layer The layer to be animated.
  @param values The values to be used in the animation. Must contain exactly two values. Supported
  UIKit types will be coerced to their Core Animation equivalent. Supported UIKit values include
  UIColor and UIBezierPath.
  @param keyPath The key path of the property to be animated.
  */
-- (void)animateWithTiming:(MDMMotionTiming)timing
-                  toLayer:(nonnull CALayer *)layer
-               withValues:(nonnull NSArray *)values
+- (void)animateWithTraits:(nonnull MDMAnimationTraits *)traits
+                   values:(nonnull NSArray *)values
+                    layer:(nonnull CALayer *)layer
                   keyPath:(nonnull MDMAnimatableKeyPath)keyPath;
 
 /**
- Adds a single animation to the layer with the given timing structure.
+ Adds a single animation to the layer with the given traits structure.
 
  If `additive` is disabled, the animation will be added to the layer with the keyPath as its key.
  In this case, multiple invocations of this function on the same key path will remove the
  animations added from prior invocations.
 
- @param timing The timing to be used for the animation.
+ @param traits The traits to be used for the animation.
  @param layer The layer to be animated.
  @param values The values to be used in the animation. Must contain exactly two values. Supported
  UIKit types will be coerced to their Core Animation equivalent. Supported UIKit values include
@@ -103,39 +103,42 @@ NS_SWIFT_NAME(MotionAnimator)
  @param keyPath The key path of the property to be animated.
  @param completion A block object to be executed when the animation ends or is removed from the
  animation hierarchy. If the duration of the animation is 0, this block is executed immediately.
- The block is escaping and will be released once the animations have completed.
+ The block is escaping and will be released once the animations have completed. The provided
+ didComplete argument is currently always YES.
  */
-- (void)animateWithTiming:(MDMMotionTiming)timing
-                  toLayer:(nonnull CALayer *)layer
-               withValues:(nonnull NSArray *)values
+- (void)animateWithTraits:(nonnull MDMAnimationTraits *)traits
+                   values:(nonnull NSArray *)values
+                    layer:(nonnull CALayer *)layer
                   keyPath:(nonnull MDMAnimatableKeyPath)keyPath
-               completion:(nullable void(^)(void))completion;
+               completion:(nullable void(^)(BOOL didComplete))completion;
 
 /**
- Performs `animations` using the timing provided.
+ Performs `animations` using the traits provided.
 
- @param timing The timing to be used for the animation.
+ @param traits The traits to be used for the animation.
  @param animations The block to be executed. Any animatable properties changed within this block
- will result in animations being added to the view's layer with the provided timing. The block is
+ will result in animations being added to the view's layer with the provided traits. The block is
  non-escaping.
  */
-- (void)animateWithTiming:(MDMMotionTiming)timing animations:(nonnull void(^)(void))animations;
+- (void)animateWithTraits:(nonnull MDMAnimationTraits *)traits
+               animations:(nonnull void(^)(void))animations;
 
 /**
- Performs `animations` using the timing provided and executes the completion handler once all added
+ Performs `animations` using the traits provided and executes the completion handler once all added
  animations have completed.
 
- @param timing The timing to be used for the animation.
+ @param traits The traits to be used for the animation.
  @param animations The block to be executed. Any animatable properties changed within this block
- will result in animations being added to the view's layer with the provided timing. The block is
+ will result in animations being added to the view's layer with the provided traits. The block is
  non-escaping.
  @param completion A block object to be executed once the animation sequence ends or it has been
  removed from the animation hierarchy. If the duration of the animation is 0, this block is executed
- immediately. The block is escaping and will be released once the animation sequence has completed.
+ immediately. The block is escaping and will be released once the animation sequence has completed. The provided
+ didComplete argument is currently always YES.
  */
-- (void)animateWithTiming:(MDMMotionTiming)timing
+- (void)animateWithTraits:(nonnull MDMAnimationTraits *)traits
                animations:(nonnull void (^)(void))animations
-               completion:(nullable void(^)(void))completion;
+               completion:(nullable void(^)(BOOL didComplete))completion;
 
 /**
  Removes every animation added by this animator.
@@ -153,6 +156,40 @@ NS_SWIFT_NAME(MotionAnimator)
  in-flight animations are stopped at their current on-screen position.
  */
 - (void)stopAllAnimations;
+
+@end
+
+@interface MDMMotionAnimator (Legacy)
+
+/**
+ To be deprecated. Use animateWithTraits:values:layer:keyPath instead.
+ */
+- (void)animateWithTiming:(MDMMotionTiming)timing
+                  toLayer:(nonnull CALayer *)layer
+               withValues:(nonnull NSArray *)values
+                  keyPath:(nonnull MDMAnimatableKeyPath)keyPath;
+
+/**
+ To be deprecated. Use animateWithTraits:values:layer:keyPath:completion: instead.
+ */
+- (void)animateWithTiming:(MDMMotionTiming)timing
+                  toLayer:(nonnull CALayer *)layer
+               withValues:(nonnull NSArray *)values
+                  keyPath:(nonnull MDMAnimatableKeyPath)keyPath
+               completion:(nullable void(^)(void))completion;
+
+/**
+ To be deprecated. Use animateWithTraits:animations: instead.
+ */
+- (void)animateWithTiming:(MDMMotionTiming)timing
+               animations:(nonnull void(^)(void))animations;
+
+/**
+ To be deprecated. Use animateWithTraits:animations:completion: instead.
+ */
+- (void)animateWithTiming:(MDMMotionTiming)timing
+               animations:(nonnull void (^)(void))animations
+               completion:(nullable void(^)(void))completion;
 
 @end
 

--- a/src/MDMMotionAnimator.h
+++ b/src/MDMMotionAnimator.h
@@ -32,6 +32,8 @@
 NS_SWIFT_NAME(MotionAnimator)
 @interface MDMMotionAnimator : NSObject <MDMCoreAnimationTraceable>
 
+#pragma mark - Configuring animation behavior
+
 /**
  The scaling factor to apply to all time-related values.
 
@@ -40,15 +42,6 @@ NS_SWIFT_NAME(MotionAnimator)
  1.0 by default.
  */
 @property(nonatomic, assign) CGFloat timeScaleFactor;
-
-/**
- If enabled, explicitly-provided values will be reversed before animating.
-
- This property does not affect the animateWithTraits:animations: family of methods.
-
- Disabled by default.
- */
-@property(nonatomic, assign) BOOL shouldReverseValues;
 
 /**
  If enabled, all animations will start from their current presentation value.
@@ -69,6 +62,8 @@ NS_SWIFT_NAME(MotionAnimator)
  */
 @property(nonatomic, assign) BOOL additive;
 
+#pragma mark - Explicitly animating between values
+
 /**
  Adds a single animation to the layer with the given traits structure.
 
@@ -84,7 +79,7 @@ NS_SWIFT_NAME(MotionAnimator)
  @param keyPath The key path of the property to be animated.
  */
 - (void)animateWithTraits:(nonnull MDMAnimationTraits *)traits
-                   values:(nonnull NSArray *)values
+                  between:(nonnull NSArray *)values
                     layer:(nonnull CALayer *)layer
                   keyPath:(nonnull MDMAnimatableKeyPath)keyPath;
 
@@ -107,10 +102,21 @@ NS_SWIFT_NAME(MotionAnimator)
  didComplete argument is currently always YES.
  */
 - (void)animateWithTraits:(nonnull MDMAnimationTraits *)traits
-                   values:(nonnull NSArray *)values
+                  between:(nonnull NSArray *)values
                     layer:(nonnull CALayer *)layer
                   keyPath:(nonnull MDMAnimatableKeyPath)keyPath
                completion:(nullable void(^)(BOOL didComplete))completion;
+
+/**
+ If enabled, explicitly-provided values will be reversed before animating.
+
+ This property only affects the animateWithTraits:between:... family of methods.
+
+ Disabled by default.
+ */
+@property(nonatomic, assign) BOOL shouldReverseValues;
+
+#pragma mark - Implicitly animating
 
 /**
  Performs `animations` using the traits provided.
@@ -140,6 +146,8 @@ NS_SWIFT_NAME(MotionAnimator)
                animations:(nonnull void (^)(void))animations
                completion:(nullable void(^)(BOOL didComplete))completion;
 
+#pragma mark - Managing active animations
+
 /**
  Removes every animation added by this animator.
 
@@ -162,7 +170,7 @@ NS_SWIFT_NAME(MotionAnimator)
 @interface MDMMotionAnimator (Legacy)
 
 /**
- To be deprecated. Use animateWithTraits:values:layer:keyPath instead.
+ To be deprecated. Use animateWithTraits:between:layer:keyPath instead.
  */
 - (void)animateWithTiming:(MDMMotionTiming)timing
                   toLayer:(nonnull CALayer *)layer
@@ -170,7 +178,7 @@ NS_SWIFT_NAME(MotionAnimator)
                   keyPath:(nonnull MDMAnimatableKeyPath)keyPath;
 
 /**
- To be deprecated. Use animateWithTraits:values:layer:keyPath:completion: instead.
+ To be deprecated. Use animateWithTraits:between:layer:keyPath:completion: instead.
  */
 - (void)animateWithTiming:(MDMMotionTiming)timing
                   toLayer:(nonnull CALayer *)layer

--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -80,7 +80,7 @@
     return;
   }
 
-  CABasicAnimation *animation = MDMAnimationFromTiming(traits, timeScaleFactor);
+  CABasicAnimation *animation = MDMAnimationFromTraits(traits, timeScaleFactor);
 
   if (animation == nil) {
     exitEarly();
@@ -142,7 +142,7 @@
   }
 
   // We'll reuse this animation template for each action.
-  CABasicAnimation *animationTemplate = MDMAnimationFromTiming(traits, timeScaleFactor);
+  CABasicAnimation *animationTemplate = MDMAnimationFromTraits(traits, timeScaleFactor);
   if (animationTemplate == nil) {
     exitEarly();
     return;

--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -41,14 +41,14 @@
 }
 
 - (void)animateWithTraits:(MDMAnimationTraits *)traits
-                   values:(NSArray *)values
+                  between:(NSArray *)values
                     layer:(CALayer *)layer
                   keyPath:(MDMAnimatableKeyPath)keyPath {
-  [self animateWithTraits:traits values:values layer:layer keyPath:keyPath completion:nil];
+  [self animateWithTraits:traits between:values layer:layer keyPath:keyPath completion:nil];
 }
 
 - (void)animateWithTraits:(MDMAnimationTraits *)traits
-                   values:(NSArray *)values
+                  between:(NSArray *)values
                     layer:(CALayer *)layer
                   keyPath:(MDMAnimatableKeyPath)keyPath
                completion:(void(^)(BOOL))completion {
@@ -218,7 +218,7 @@
                withValues:(NSArray *)values
                   keyPath:(MDMAnimatableKeyPath)keyPath {
   MDMAnimationTraits *traits = [[MDMAnimationTraits alloc] initWithMotionTiming:timing];
-  [self animateWithTraits:traits values:values layer:layer keyPath:keyPath];
+  [self animateWithTraits:traits between:values layer:layer keyPath:keyPath];
 }
 
 - (void)animateWithTiming:(MDMMotionTiming)timing
@@ -228,7 +228,7 @@
                completion:(void (^)(void))completion {
   MDMAnimationTraits *traits = [[MDMAnimationTraits alloc] initWithMotionTiming:timing];
   [self animateWithTraits:traits
-                   values:values
+            between:values
                     layer:layer
                   keyPath:keyPath
                completion:^(BOOL didComplete) {

--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -228,7 +228,7 @@
                completion:(void (^)(void))completion {
   MDMAnimationTraits *traits = [[MDMAnimationTraits alloc] initWithMotionTiming:timing];
   [self animateWithTraits:traits
-            between:values
+                  between:values
                     layer:layer
                   keyPath:keyPath
                completion:^(BOOL didComplete) {

--- a/src/private/CABasicAnimation+MotionAnimator.h
+++ b/src/private/CABasicAnimation+MotionAnimator.h
@@ -22,7 +22,7 @@
 
 // Returns a basic animation configured with the provided traits and scale factor.
 FOUNDATION_EXPORT
-CABasicAnimation *MDMAnimationFromTiming(MDMAnimationTraits * traits, CGFloat timeScaleFactor);
+CABasicAnimation *MDMAnimationFromTraits(MDMAnimationTraits *traits, CGFloat timeScaleFactor);
 
 // Returns a Boolean indicating whether or not an animation with the given key path and toValue
 // can be animated additively.
@@ -33,4 +33,4 @@ FOUNDATION_EXPORT BOOL MDMCanAnimationBeAdditive(NSString *keyPath, id toValue);
 //
 // Not all animation value types support being additive. If an animation's value type was not
 // supported, the animation's values will not be modified.
-FOUNDATION_EXPORT void MDMConfigureAnimation(CABasicAnimation *animation, MDMAnimationTraits * traits);
+FOUNDATION_EXPORT void MDMConfigureAnimation(CABasicAnimation *animation, MDMAnimationTraits *traits);

--- a/src/private/CABasicAnimation+MotionAnimator.h
+++ b/src/private/CABasicAnimation+MotionAnimator.h
@@ -20,9 +20,9 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <QuartzCore/QuartzCore.h>
 
-// Returns a basic animation configured with the provided timing and scale factor.
+// Returns a basic animation configured with the provided traits and scale factor.
 FOUNDATION_EXPORT
-CABasicAnimation *MDMAnimationFromTiming(MDMMotionTiming timing, CGFloat timeScaleFactor);
+CABasicAnimation *MDMAnimationFromTiming(MDMAnimationTraits * traits, CGFloat timeScaleFactor);
 
 // Returns a Boolean indicating whether or not an animation with the given key path and toValue
 // can be animated additively.
@@ -33,4 +33,4 @@ FOUNDATION_EXPORT BOOL MDMCanAnimationBeAdditive(NSString *keyPath, id toValue);
 //
 // Not all animation value types support being additive. If an animation's value type was not
 // supported, the animation's values will not be modified.
-FOUNDATION_EXPORT void MDMConfigureAnimation(CABasicAnimation *animation, MDMMotionTiming timing);
+FOUNDATION_EXPORT void MDMConfigureAnimation(CABasicAnimation *animation, MDMAnimationTraits * traits);

--- a/src/private/CABasicAnimation+MotionAnimator.m
+++ b/src/private/CABasicAnimation+MotionAnimator.m
@@ -65,7 +65,7 @@ static BOOL IsAnimationKeyPathAlwaysNonAdditive(NSString *keyPath) {
 
 #pragma mark - Public
 
-CABasicAnimation *MDMAnimationFromTiming(MDMAnimationTraits * traits, CGFloat timeScaleFactor) {
+CABasicAnimation *MDMAnimationFromTraits(MDMAnimationTraits *traits, CGFloat timeScaleFactor) {
   if (traits.timingCurve == nil) {
     return nil;
   }

--- a/src/private/CAMediaTimingFunction+MotionAnimator.h
+++ b/src/private/CAMediaTimingFunction+MotionAnimator.h
@@ -18,6 +18,6 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <QuartzCore/QuartzCore.h>
 
-// Returns a timing function with the given control points.
+// Returns a traits function with the given control points.
 FOUNDATION_EXPORT
 CAMediaTimingFunction* MDMTimingFunctionWithControlPoints(CGFloat controlPoints[4]);

--- a/src/private/CAMediaTimingFunction+MotionAnimator.h
+++ b/src/private/CAMediaTimingFunction+MotionAnimator.h
@@ -18,6 +18,6 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <QuartzCore/QuartzCore.h>
 
-// Returns a traits function with the given control points.
+// Returns a timing function with the given control points.
 FOUNDATION_EXPORT
 CAMediaTimingFunction* MDMTimingFunctionWithControlPoints(CGFloat controlPoints[4]);

--- a/src/private/MDMAnimationRegistrar.h
+++ b/src/private/MDMAnimationRegistrar.h
@@ -26,7 +26,7 @@
 - (void)addAnimation:(nonnull CABasicAnimation *)animation
              toLayer:(nonnull CALayer *)layer
               forKey:(nonnull NSString *)key
-          completion:(void(^ __nullable)(void))completion;
+          completion:(void(^ __nullable)(BOOL))completion;
 
 // For every active animation, reads the associated layer's presentation layer key path and writes
 // it to the layer.

--- a/src/private/MDMAnimationRegistrar.m
+++ b/src/private/MDMAnimationRegistrar.m
@@ -54,7 +54,7 @@
 - (void)addAnimation:(CABasicAnimation *)animation
                 toLayer:(CALayer *)layer
                  forKey:(NSString *)key
-             completion:(void(^)(void))completion {
+             completion:(void(^)(BOOL))completion {
   if (key == nil) {
     key = [NSUUID UUID].UUIDString;
   }
@@ -73,7 +73,7 @@
     [animatedKeyPaths removeObject:keyPathAnimation];
 
     if (completion) {
-      completion();
+      completion(YES);
     }
   }];
 

--- a/src/private/MDMUIKitValueCoercion.h
+++ b/src/private/MDMUIKitValueCoercion.h
@@ -16,10 +16,11 @@
 
 #import <Foundation/Foundation.h>
 
-// Coerces the following UIKit values to Core Animation between:
+// Coerces the following UIKit/CoreGraphics values to Core Animation values:
 //
 // - UIBezierPath -> CGPath
 // - UIColor -> CGColor
+// - CGAffineTransform -> CATransform3D
 //
 // @param values All values of this array must be the same type.
 FOUNDATION_EXPORT NSArray* MDMCoerceUIKitValuesToCoreAnimationValues(NSArray *values);

--- a/src/private/MDMUIKitValueCoercion.h
+++ b/src/private/MDMUIKitValueCoercion.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-// Coerces the following UIKit values to Core Animation values:
+// Coerces the following UIKit values to Core Animation between:
 //
 // - UIBezierPath -> CGPath
 // - UIColor -> CGColor

--- a/tests/unit/AdditiveAnimatorTests.swift
+++ b/tests/unit/AdditiveAnimatorTests.swift
@@ -23,7 +23,7 @@ import MotionAnimator
 
 class AdditiveAnimationTests: XCTestCase {
   var animator: MotionAnimator!
-  var timing: MotionTiming!
+  var traits: MDMAnimationTraits!
   var view: UIView!
 
   override func setUp() {
@@ -33,10 +33,7 @@ class AdditiveAnimationTests: XCTestCase {
 
     animator.additive = true
 
-    timing = MotionTiming(delay: 0,
-                          duration: 1,
-                          curve: MotionCurveMakeBezier(p1x: 0, p1y: 0, p2x: 1, p2y: 1),
-                          repetition: .init(type: .none, amount: 0, autoreverses: false))
+    traits = MDMAnimationTraits(duration: 1)
 
     let window = UIWindow()
     window.makeKeyAndVisible()
@@ -49,14 +46,15 @@ class AdditiveAnimationTests: XCTestCase {
 
   override func tearDown() {
     animator = nil
-    timing = nil
+    traits = nil
     view = nil
 
     super.tearDown()
   }
 
   func testNumericKeyPathsAnimateAdditively() {
-    animator.animate(with: timing, to: view.layer, withValues: [1, 0], keyPath: .cornerRadius)
+    animator.animate(with: traits, values: [1, 0],
+                     layer: view.layer, keyPath: .cornerRadius)
 
     XCTAssertNotNil(view.layer.animationKeys(),
                     "Expected an animation to be added, but none were found.")
@@ -75,9 +73,9 @@ class AdditiveAnimationTests: XCTestCase {
   }
 
   func testCGSizeKeyPathsAnimateAdditively() {
-    animator.animate(with: timing, to: view.layer,
-                     withValues: [CGSize(width: 0, height: 0),
-                                  CGSize(width: 1, height: 2)], keyPath: .shadowOffset)
+    animator.animate(with: traits, values: [CGSize(width: 0, height: 0),
+                                            CGSize(width: 1, height: 2)],
+                     layer: view.layer, keyPath: .shadowOffset)
 
     XCTAssertNotNil(view.layer.animationKeys(),
                     "Expected an animation to be added, but none were found.")
@@ -96,9 +94,8 @@ class AdditiveAnimationTests: XCTestCase {
   }
 
   func testCGPointKeyPathsAnimateAdditively() {
-    animator.animate(with: timing, to: view.layer,
-                     withValues: [CGPoint(x: 0, y: 0),
-                                  CGPoint(x: 1, y: 2)], keyPath: .position)
+    animator.animate(with: traits, values: [CGPoint(x: 0, y: 0), CGPoint(x: 1, y: 2)],
+                     layer: view.layer, keyPath: .position)
 
     XCTAssertNotNil(view.layer.animationKeys(),
                     "Expected an animation to be added, but none were found.")

--- a/tests/unit/AdditiveAnimatorTests.swift
+++ b/tests/unit/AdditiveAnimatorTests.swift
@@ -53,7 +53,7 @@ class AdditiveAnimationTests: XCTestCase {
   }
 
   func testNumericKeyPathsAnimateAdditively() {
-    animator.animate(with: traits, values: [1, 0],
+    animator.animate(with: traits, between: [1, 0],
                      layer: view.layer, keyPath: .cornerRadius)
 
     XCTAssertNotNil(view.layer.animationKeys(),
@@ -73,7 +73,7 @@ class AdditiveAnimationTests: XCTestCase {
   }
 
   func testCGSizeKeyPathsAnimateAdditively() {
-    animator.animate(with: traits, values: [CGSize(width: 0, height: 0),
+    animator.animate(with: traits, between: [CGSize(width: 0, height: 0),
                                             CGSize(width: 1, height: 2)],
                      layer: view.layer, keyPath: .shadowOffset)
 
@@ -94,7 +94,7 @@ class AdditiveAnimationTests: XCTestCase {
   }
 
   func testCGPointKeyPathsAnimateAdditively() {
-    animator.animate(with: traits, values: [CGPoint(x: 0, y: 0), CGPoint(x: 1, y: 2)],
+    animator.animate(with: traits, between: [CGPoint(x: 0, y: 0), CGPoint(x: 1, y: 2)],
                      layer: view.layer, keyPath: .position)
 
     XCTAssertNotNil(view.layer.animationKeys(),

--- a/tests/unit/AnimationRemovalTests.swift
+++ b/tests/unit/AnimationRemovalTests.swift
@@ -52,8 +52,8 @@ class AnimationRemovalTests: XCTestCase {
   }
 
   func testAllAdditiveAnimationsGetsRemoved() {
-    animator.animate(with: traits, values: [1, 0], layer: view.layer, keyPath: .cornerRadius)
-    animator.animate(with: traits, values: [0, 0.5], layer: view.layer, keyPath: .cornerRadius)
+    animator.animate(with: traits, between: [1, 0], layer: view.layer, keyPath: .cornerRadius)
+    animator.animate(with: traits, between: [0, 0.5], layer: view.layer, keyPath: .cornerRadius)
 
     XCTAssertEqual(view.layer.animationKeys()!.count, 2)
 
@@ -70,8 +70,8 @@ class AnimationRemovalTests: XCTestCase {
       didComplete = true
     }
 
-    animator.animate(with: traits, values: [1, 0], layer: view.layer, keyPath: .cornerRadius)
-    animator.animate(with: traits, values: [0, 0.5], layer: view.layer, keyPath: .cornerRadius)
+    animator.animate(with: traits, between: [1, 0], layer: view.layer, keyPath: .cornerRadius)
+    animator.animate(with: traits, between: [0, 0.5], layer: view.layer, keyPath: .cornerRadius)
 
     CATransaction.commit()
 

--- a/tests/unit/AnimationRemovalTests.swift
+++ b/tests/unit/AnimationRemovalTests.swift
@@ -24,7 +24,7 @@ import MotionAnimator
 
 class AnimationRemovalTests: XCTestCase {
   var animator: MotionAnimator!
-  var timing: MotionTiming!
+  var traits: MDMAnimationTraits!
   var view: UIView!
 
   var originalImplementation: IMP?
@@ -32,10 +32,7 @@ class AnimationRemovalTests: XCTestCase {
     super.setUp()
 
     animator = MotionAnimator()
-    timing = MotionTiming(delay: 0,
-                          duration: 1,
-                          curve: MotionCurveMakeBezier(p1x: 0, p1y: 0, p2x: 0, p2y: 0),
-                          repetition: .init(type: .none, amount: 0, autoreverses: false))
+    traits = MDMAnimationTraits(duration: 1)
 
     let window = UIWindow()
     window.makeKeyAndVisible()
@@ -48,15 +45,15 @@ class AnimationRemovalTests: XCTestCase {
 
   override func tearDown() {
     animator = nil
-    timing = nil
+    traits = nil
     view = nil
 
     super.tearDown()
   }
 
   func testAllAdditiveAnimationsGetsRemoved() {
-    animator.animate(with: timing, to: view.layer, withValues: [1, 0], keyPath: .cornerRadius)
-    animator.animate(with: timing, to: view.layer, withValues: [0, 0.5], keyPath: .cornerRadius)
+    animator.animate(with: traits, values: [1, 0], layer: view.layer, keyPath: .cornerRadius)
+    animator.animate(with: traits, values: [0, 0.5], layer: view.layer, keyPath: .cornerRadius)
 
     XCTAssertEqual(view.layer.animationKeys()!.count, 2)
 
@@ -73,8 +70,8 @@ class AnimationRemovalTests: XCTestCase {
       didComplete = true
     }
 
-    animator.animate(with: timing, to: view.layer, withValues: [1, 0], keyPath: .cornerRadius)
-    animator.animate(with: timing, to: view.layer, withValues: [0, 0.5], keyPath: .cornerRadius)
+    animator.animate(with: traits, values: [1, 0], layer: view.layer, keyPath: .cornerRadius)
+    animator.animate(with: traits, values: [0, 0.5], layer: view.layer, keyPath: .cornerRadius)
 
     CATransaction.commit()
 

--- a/tests/unit/BeginFromCurrentStateTests.swift
+++ b/tests/unit/BeginFromCurrentStateTests.swift
@@ -24,7 +24,7 @@ import MotionAnimator
 
 class BeginFromCurrentStateTests: XCTestCase {
   var animator: MotionAnimator!
-  var timing: MotionTiming!
+  var traits: MDMAnimationTraits!
   var view: UIView!
   var addedAnimations: [CAAnimation]!
 
@@ -35,10 +35,7 @@ class BeginFromCurrentStateTests: XCTestCase {
 
     animator.beginFromCurrentState = true
 
-    timing = MotionTiming(delay: 0,
-                          duration: 1,
-                          curve: MotionCurveMakeBezier(p1x: 0, p1y: 0, p2x: 0, p2y: 0),
-                          repetition: .init(type: .none, amount: 0, autoreverses: false))
+    traits = MDMAnimationTraits(duration: 1)
 
     let window = UIWindow()
     window.makeKeyAndVisible()
@@ -56,7 +53,7 @@ class BeginFromCurrentStateTests: XCTestCase {
 
   override func tearDown() {
     animator = nil
-    timing = nil
+    traits = nil
     view = nil
     addedAnimations = nil
 
@@ -68,7 +65,8 @@ class BeginFromCurrentStateTests: XCTestCase {
 
     animator.additive = false
 
-    animator.animate(with: timing, to: view.layer, withValues: [0, 0.5], keyPath: .opacity)
+    animator.animate(with: traits, values: [0, 0.5],
+                     layer: view.layer, keyPath: .opacity)
 
     XCTAssertNotNil(view.layer.animationKeys(),
                     "Expected an animation to be added, but none were found.")
@@ -103,7 +101,7 @@ class BeginFromCurrentStateTests: XCTestCase {
 
     animator.additive = false
 
-    animator.animate(with: timing) {
+    animator.animate(with: traits) {
       self.view.alpha = 0.5
     }
 
@@ -138,7 +136,8 @@ class BeginFromCurrentStateTests: XCTestCase {
   func testExplicitlyAnimatesFromPresentationValue() {
     animator.additive = false
 
-    animator.animate(with: timing, to: view.layer, withValues: [0, 0.5], keyPath: .opacity)
+    animator.animate(with: traits, values: [0, 0.5],
+                     layer: view.layer, keyPath: .opacity)
     RunLoop.main.run(until: .init(timeIntervalSinceNow: 0.01))
 
     XCTAssertNotNil(view.layer.presentation(), "No presentation layer found.")
@@ -147,7 +146,8 @@ class BeginFromCurrentStateTests: XCTestCase {
     }
     let initialValue = presentation.opacity
 
-    animator.animate(with: timing, to: view.layer, withValues: [0, 0.2], keyPath: .opacity)
+    animator.animate(with: traits, values: [0, 0.2],
+                     layer: view.layer, keyPath: .opacity)
 
     XCTAssertNotNil(view.layer.animationKeys(),
                     "Expected an animation to be added, but none were found.")
@@ -180,7 +180,8 @@ class BeginFromCurrentStateTests: XCTestCase {
   func testImplicitlyAnimatesFromPresentationValue() {
     animator.additive = false
 
-    animator.animate(with: timing, to: view.layer, withValues: [0, 0.5], keyPath: .opacity)
+    animator.animate(with: traits, values: [0, 0.5],
+                     layer: view.layer, keyPath: .opacity)
 
     RunLoop.main.run(until: .init(timeIntervalSinceNow: 0.01))
 
@@ -190,7 +191,7 @@ class BeginFromCurrentStateTests: XCTestCase {
     }
     let initialValue = presentation.opacity
 
-    animator.animate(with: timing) {
+    animator.animate(with: traits) {
       self.view.alpha = 0.2
     }
 
@@ -226,7 +227,7 @@ class BeginFromCurrentStateTests: XCTestCase {
     animator.beginFromCurrentState = true
     animator.additive = false
 
-    animator.animate(with: timing) {
+    animator.animate(with: traits) {
       self.view.alpha = 0.5
     }
 
@@ -234,7 +235,7 @@ class BeginFromCurrentStateTests: XCTestCase {
 
     let initialValue = view.layer.presentation()!.opacity
 
-    animator.animate(with: timing) {
+    animator.animate(with: traits) {
       self.view.alpha = 1.0
     }
 

--- a/tests/unit/BeginFromCurrentStateTests.swift
+++ b/tests/unit/BeginFromCurrentStateTests.swift
@@ -65,7 +65,7 @@ class BeginFromCurrentStateTests: XCTestCase {
 
     animator.additive = false
 
-    animator.animate(with: traits, values: [0, 0.5],
+    animator.animate(with: traits, between: [0, 0.5],
                      layer: view.layer, keyPath: .opacity)
 
     XCTAssertNotNil(view.layer.animationKeys(),
@@ -136,7 +136,7 @@ class BeginFromCurrentStateTests: XCTestCase {
   func testExplicitlyAnimatesFromPresentationValue() {
     animator.additive = false
 
-    animator.animate(with: traits, values: [0, 0.5],
+    animator.animate(with: traits, between: [0, 0.5],
                      layer: view.layer, keyPath: .opacity)
     RunLoop.main.run(until: .init(timeIntervalSinceNow: 0.01))
 
@@ -146,7 +146,7 @@ class BeginFromCurrentStateTests: XCTestCase {
     }
     let initialValue = presentation.opacity
 
-    animator.animate(with: traits, values: [0, 0.2],
+    animator.animate(with: traits, between: [0, 0.2],
                      layer: view.layer, keyPath: .opacity)
 
     XCTAssertNotNil(view.layer.animationKeys(),
@@ -180,7 +180,7 @@ class BeginFromCurrentStateTests: XCTestCase {
   func testImplicitlyAnimatesFromPresentationValue() {
     animator.additive = false
 
-    animator.animate(with: traits, values: [0, 0.5],
+    animator.animate(with: traits, between: [0, 0.5],
                      layer: view.layer, keyPath: .opacity)
 
     RunLoop.main.run(until: .init(timeIntervalSinceNow: 0.01))

--- a/tests/unit/HeadlessLayerImplicitAnimationTests.swift
+++ b/tests/unit/HeadlessLayerImplicitAnimationTests.swift
@@ -97,7 +97,7 @@ class HeadlessLayerImplicitAnimationTests: XCTestCase {
 
   // Verifies the somewhat counter-intuitive fact that CATransaction's animation duration always
   // takes precedence over UIView's animation duration. This means that animating a headless layer
-  // using UIView animation APIs may not result in the expected traitss.
+  // using UIView animation APIs may not result in the expected traits.
   func testCATransactionTimingTakesPrecedenceOverUIViewTimingOutside() {
     CATransaction.begin()
     CATransaction.setAnimationDuration(0.2)

--- a/tests/unit/HeadlessLayerImplicitAnimationTests.swift
+++ b/tests/unit/HeadlessLayerImplicitAnimationTests.swift
@@ -97,7 +97,7 @@ class HeadlessLayerImplicitAnimationTests: XCTestCase {
 
   // Verifies the somewhat counter-intuitive fact that CATransaction's animation duration always
   // takes precedence over UIView's animation duration. This means that animating a headless layer
-  // using UIView animation APIs may not result in the expected timings.
+  // using UIView animation APIs may not result in the expected traitss.
   func testCATransactionTimingTakesPrecedenceOverUIViewTimingOutside() {
     CATransaction.begin()
     CATransaction.setAnimationDuration(0.2)
@@ -146,18 +146,19 @@ class HeadlessLayerImplicitAnimationTests: XCTestCase {
   func testAnimatorTimingTakesPrecedenceOverCATransactionTiming() {
     let animator = MotionAnimator()
     animator.additive = false
-    let timing = MotionTiming(delay: 0,
-                              duration: 1,
-                              curve: MotionCurveMakeBezier(p1x: 0, p1y: 0, p2x: 0, p2y: 0),
-                              repetition: .init(type: .none, amount: 0, autoreverses: false))
 
-    animator.animate(with: timing) {
+    let traits = MDMAnimationTraits(duration: 1)
+
+    CATransaction.begin()
+    CATransaction.setAnimationDuration(0.5)
+    animator.animate(with: traits) {
       self.layer.opacity = 0.5
     }
+    CATransaction.commit()
 
     let animation = layer.animation(forKey: "opacity") as! CABasicAnimation
     XCTAssertEqual(animation.keyPath, "opacity")
-    XCTAssertEqual(animation.duration, timing.duration)
+    XCTAssertEqual(animation.duration, traits.duration)
   }
 
   // MARK: Deprecated tests.
@@ -204,12 +205,9 @@ class HeadlessLayerImplicitAnimationTests: XCTestCase {
 
     let animator = MotionAnimator()
     animator.additive = false
-    let timing = MotionTiming(delay: 0,
-                              duration: 1,
-                              curve: MotionCurveMakeBezier(p1x: 0, p1y: 0, p2x: 0, p2y: 0),
-                              repetition: .init(type: .none, amount: 0, autoreverses: false))
+    let traits = MDMAnimationTraits(duration: 1)
 
-    animator.animate(with: timing) {
+    animator.animate(with: traits) {
       self.layer.opacity = 0.5
     }
 

--- a/tests/unit/ImplicitAnimationTests.swift
+++ b/tests/unit/ImplicitAnimationTests.swift
@@ -23,7 +23,7 @@ import MotionAnimator
 
 class ImplicitAnimationTests: XCTestCase {
   var animator: MotionAnimator!
-  var timing: MotionTiming!
+  var traits: MDMAnimationTraits!
   var view: UIView!
   var addedAnimations: [CAAnimation]!
 
@@ -34,10 +34,7 @@ class ImplicitAnimationTests: XCTestCase {
     animator = MotionAnimator()
     animator.additive = false
 
-    timing = MotionTiming(delay: 0,
-                          duration: 0.7,
-                          curve: MotionCurveMakeBezier(p1x: 0, p1y: 0, p2x: 1, p2y: 1),
-                          repetition: .init(type: .none, amount: 0, autoreverses: false))
+    traits = MDMAnimationTraits(duration: 1)
 
     let window = UIWindow()
     window.makeKeyAndVisible()
@@ -69,7 +66,7 @@ class ImplicitAnimationTests: XCTestCase {
   }
 
   func testNoActionAddsNoAnimations() {
-    animator.animate(with: timing) {
+    animator.animate(with: traits) {
       // No-op
     }
 
@@ -77,7 +74,7 @@ class ImplicitAnimationTests: XCTestCase {
   }
 
   func testOneActionAddsOneAnimation() {
-    animator.animate(with: timing) {
+    animator.animate(with: traits) {
       self.view.alpha = 0
     }
 
@@ -86,18 +83,21 @@ class ImplicitAnimationTests: XCTestCase {
     XCTAssertEqual(animation.keyPath, AnimatableKeyPath.opacity.rawValue)
     XCTAssertEqual(animation.fromValue as! CGFloat, 1)
     XCTAssertEqual(animation.toValue as! CGFloat, 0)
-    XCTAssertEqual(animation.duration, timing.duration)
+    XCTAssertEqual(animation.duration, traits.duration)
 
-    let addedCurve = MotionCurve(fromTimingFunction: animation.timingFunction!)
-    XCTAssertEqual(addedCurve.type, timing.curve.type)
-    XCTAssertEqual(addedCurve.data.0, timing.curve.data.0)
-    XCTAssertEqual(addedCurve.data.1, timing.curve.data.1)
-    XCTAssertEqual(addedCurve.data.2, timing.curve.data.2)
-    XCTAssertEqual(addedCurve.data.3, timing.curve.data.3)
+    let timingCurve = traits.timingCurve as! CAMediaTimingFunction
+    XCTAssertEqualWithAccuracy(timingCurve.mdm_point1.x, animation.timingFunction!.mdm_point1.x,
+                               accuracy: 0.001)
+    XCTAssertEqualWithAccuracy(timingCurve.mdm_point1.y, animation.timingFunction!.mdm_point1.y,
+                               accuracy: 0.001)
+    XCTAssertEqualWithAccuracy(timingCurve.mdm_point2.x, animation.timingFunction!.mdm_point2.x,
+                               accuracy: 0.001)
+    XCTAssertEqualWithAccuracy(timingCurve.mdm_point2.y, animation.timingFunction!.mdm_point2.y,
+                               accuracy: 0.001)
   }
 
   func testTwoActionsAddsTwoAnimations() {
-    animator.animate(with: timing) {
+    animator.animate(with: traits) {
       self.view.alpha = 0
       self.view.center = .init(x: 50, y: 50)
     }
@@ -110,14 +110,17 @@ class ImplicitAnimationTests: XCTestCase {
       XCTAssertEqual(animation.keyPath, AnimatableKeyPath.opacity.rawValue)
       XCTAssertEqual(animation.fromValue as! CGFloat, 1)
       XCTAssertEqual(animation.toValue as! CGFloat, 0)
-      XCTAssertEqual(animation.duration, timing.duration)
+      XCTAssertEqual(animation.duration, traits.duration)
 
-      let addedCurve = MotionCurve(fromTimingFunction: animation.timingFunction!)
-      XCTAssertEqual(addedCurve.type, timing.curve.type)
-      XCTAssertEqual(addedCurve.data.0, timing.curve.data.0)
-      XCTAssertEqual(addedCurve.data.1, timing.curve.data.1)
-      XCTAssertEqual(addedCurve.data.2, timing.curve.data.2)
-      XCTAssertEqual(addedCurve.data.3, timing.curve.data.3)
+      let timingCurve = traits.timingCurve as! CAMediaTimingFunction
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point1.x, animation.timingFunction!.mdm_point1.x,
+                                 accuracy: 0.001)
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point1.y, animation.timingFunction!.mdm_point1.y,
+                                 accuracy: 0.001)
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point2.x, animation.timingFunction!.mdm_point2.x,
+                                 accuracy: 0.001)
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point2.y, animation.timingFunction!.mdm_point2.y,
+                                 accuracy: 0.001)
     }
     do {
       let animation = addedAnimations[1] as! CABasicAnimation
@@ -125,19 +128,22 @@ class ImplicitAnimationTests: XCTestCase {
       XCTAssertEqual(animation.keyPath, AnimatableKeyPath.position.rawValue)
       XCTAssertEqual(animation.fromValue as! CGPoint, .init(x: 0, y: 0))
       XCTAssertEqual(animation.toValue as! CGPoint, .init(x: 50, y: 50))
-      XCTAssertEqual(animation.duration, timing.duration)
+      XCTAssertEqual(animation.duration, traits.duration)
 
-      let addedCurve = MotionCurve(fromTimingFunction: animation.timingFunction!)
-      XCTAssertEqual(addedCurve.type, timing.curve.type)
-      XCTAssertEqual(addedCurve.data.0, timing.curve.data.0)
-      XCTAssertEqual(addedCurve.data.1, timing.curve.data.1)
-      XCTAssertEqual(addedCurve.data.2, timing.curve.data.2)
-      XCTAssertEqual(addedCurve.data.3, timing.curve.data.3)
+      let timingCurve = traits.timingCurve as! CAMediaTimingFunction
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point1.x, animation.timingFunction!.mdm_point1.x,
+                                 accuracy: 0.001)
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point1.y, animation.timingFunction!.mdm_point1.y,
+                                 accuracy: 0.001)
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point2.x, animation.timingFunction!.mdm_point2.x,
+                                 accuracy: 0.001)
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point2.y, animation.timingFunction!.mdm_point2.y,
+                                 accuracy: 0.001)
     }
   }
 
   func testFrameActionAddsTwoAnimations() {
-    animator.animate(with: timing) {
+    animator.animate(with: traits) {
       self.view.frame = .init(x: 0, y: 0, width: 100, height: 100)
     }
 
@@ -150,14 +156,17 @@ class ImplicitAnimationTests: XCTestCase {
       XCTAssertFalse(animation.isAdditive)
       XCTAssertEqual(animation.fromValue as! CGPoint, .init(x: 0, y: 0))
       XCTAssertEqual(animation.toValue as! CGPoint, .init(x: 50, y: 50))
-      XCTAssertEqual(animation.duration, timing.duration)
+      XCTAssertEqual(animation.duration, traits.duration)
 
-      let addedCurve = MotionCurve(fromTimingFunction: animation.timingFunction!)
-      XCTAssertEqual(addedCurve.type, timing.curve.type)
-      XCTAssertEqual(addedCurve.data.0, timing.curve.data.0)
-      XCTAssertEqual(addedCurve.data.1, timing.curve.data.1)
-      XCTAssertEqual(addedCurve.data.2, timing.curve.data.2)
-      XCTAssertEqual(addedCurve.data.3, timing.curve.data.3)
+      let timingCurve = traits.timingCurve as! CAMediaTimingFunction
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point1.x, animation.timingFunction!.mdm_point1.x,
+                                 accuracy: 0.001)
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point1.y, animation.timingFunction!.mdm_point1.y,
+                                 accuracy: 0.001)
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point2.x, animation.timingFunction!.mdm_point2.x,
+                                 accuracy: 0.001)
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point2.y, animation.timingFunction!.mdm_point2.y,
+                                 accuracy: 0.001)
     }
     do {
       let animation = addedAnimations
@@ -166,14 +175,17 @@ class ImplicitAnimationTests: XCTestCase {
       XCTAssertFalse(animation.isAdditive)
       XCTAssertEqual(animation.fromValue as! CGRect, .init(x: 0, y: 0, width: 0, height: 0))
       XCTAssertEqual(animation.toValue as! CGRect, .init(x: 0, y: 0, width: 100, height: 100))
-      XCTAssertEqual(animation.duration, timing.duration)
+      XCTAssertEqual(animation.duration, traits.duration)
 
-      let addedCurve = MotionCurve(fromTimingFunction: animation.timingFunction!)
-      XCTAssertEqual(addedCurve.type, timing.curve.type)
-      XCTAssertEqual(addedCurve.data.0, timing.curve.data.0)
-      XCTAssertEqual(addedCurve.data.1, timing.curve.data.1)
-      XCTAssertEqual(addedCurve.data.2, timing.curve.data.2)
-      XCTAssertEqual(addedCurve.data.3, timing.curve.data.3)
+      let timingCurve = traits.timingCurve as! CAMediaTimingFunction
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point1.x, animation.timingFunction!.mdm_point1.x,
+                                 accuracy: 0.001)
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point1.y, animation.timingFunction!.mdm_point1.y,
+                                 accuracy: 0.001)
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point2.x, animation.timingFunction!.mdm_point2.x,
+                                 accuracy: 0.001)
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point2.y, animation.timingFunction!.mdm_point2.y,
+                                 accuracy: 0.001)
     }
   }
 
@@ -181,7 +193,7 @@ class ImplicitAnimationTests: XCTestCase {
     CATransaction.begin()
     CATransaction.setDisableActions(true)
 
-    animator.animate(with: timing) {
+    animator.animate(with: traits) {
       self.view.alpha = 0
     }
 
@@ -211,9 +223,9 @@ class ImplicitAnimationTests: XCTestCase {
   }
 
   func testDurationOfZeroRunsAnimationsBlockButGeneratesNoAnimations() {
-    timing.duration = 0
+    let traits = MDMAnimationTraits(duration: 0)
 
-    animator.animate(with: timing) {
+    animator.animate(with: traits) {
       self.view.alpha = 0
     }
 
@@ -224,7 +236,7 @@ class ImplicitAnimationTests: XCTestCase {
   func testTimeScaleFactorOfZeroRunsAnimationsBlockButGeneratesNoAnimations() {
     animator.timeScaleFactor = 0
 
-    animator.animate(with: timing) {
+    animator.animate(with: traits) {
       self.view.alpha = 0
     }
 
@@ -233,7 +245,7 @@ class ImplicitAnimationTests: XCTestCase {
   }
 
   func testUnsupportedAnimationKeyIsNotAnimated() {
-    animator.animate(with: timing) {
+    animator.animate(with: traits) {
       self.view.layer.sublayers = []
     }
 

--- a/tests/unit/InitialVelocityTests.swift
+++ b/tests/unit/InitialVelocityTests.swift
@@ -51,7 +51,7 @@ class InitialVelocityTests: XCTestCase {
     addedAnimations.flatMap { $0 as? CASpringAnimation }.forEach { animation in
       XCTAssertEqual(animation.initialVelocity, 0.5,
                      "from: \(animation.fromValue!), "
-                      + "to: \(animation.toValue!), "
+                      + "layer: \(animation.toValue!), "
                       + "withVelocity: \(velocity)")
     }
   }
@@ -64,7 +64,7 @@ class InitialVelocityTests: XCTestCase {
     addedAnimations.flatMap { $0 as? CASpringAnimation }.forEach { animation in
       XCTAssertEqual(animation.initialVelocity, 0.5,
                      "from: \(animation.fromValue!), "
-                      + "to: \(animation.toValue!), "
+                      + "layer: \(animation.toValue!), "
                       + "withVelocity: \(velocity)")
     }
   }
@@ -77,7 +77,7 @@ class InitialVelocityTests: XCTestCase {
     addedAnimations.flatMap { $0 as? CASpringAnimation }.forEach { animation in
       XCTAssertGreaterThan(animation.initialVelocity, 0,
                            "from: \(animation.fromValue!), "
-                            + "to: \(animation.toValue!), "
+                            + "layer: \(animation.toValue!), "
                             + "withVelocity: \(velocity)")
     }
   }
@@ -90,7 +90,7 @@ class InitialVelocityTests: XCTestCase {
     addedAnimations.flatMap { $0 as? CASpringAnimation }.forEach { animation in
       XCTAssertLessThan(animation.initialVelocity, 0,
                         "from: \(animation.fromValue!), "
-                          + "to: \(animation.toValue!), "
+                          + "layer: \(animation.toValue!), "
                           + "withVelocity: \(velocity)")
     }
   }
@@ -103,7 +103,7 @@ class InitialVelocityTests: XCTestCase {
     addedAnimations.flatMap { $0 as? CASpringAnimation }.forEach { animation in
       XCTAssertGreaterThan(animation.initialVelocity, 0,
                            "from: \(animation.fromValue!), "
-                            + "to: \(animation.toValue!), "
+                            + "layer: \(animation.toValue!), "
                             + "withVelocity: \(velocity)")
     }
   }
@@ -116,7 +116,7 @@ class InitialVelocityTests: XCTestCase {
     addedAnimations.flatMap { $0 as? CASpringAnimation }.forEach { animation in
       XCTAssertLessThan(animation.initialVelocity, 0,
                         "from: \(animation.fromValue!), "
-                          + "to: \(animation.toValue!), "
+                          + "layer: \(animation.toValue!), "
                           + "withVelocity: \(velocity)")
     }
   }
@@ -129,24 +129,23 @@ class InitialVelocityTests: XCTestCase {
     addedAnimations.flatMap { $0 as? CASpringAnimation }.forEach { animation in
       XCTAssertEqual(animation.duration, animation.settlingDuration,
                      "from: \(animation.fromValue!), "
-                      + "to: \(animation.toValue!), "
+                      + "layer: \(animation.toValue!), "
                       + "withVelocity: \(velocity)")
     }
   }
 
   private func animate(from: CGFloat, to: CGFloat, withVelocity velocity: CGFloat) {
-    let timing = MotionTiming(delay: 0,
-                              duration: 0.7,
-                              curve: .init(type: .spring, data: (1, 1, 1, velocity)),
-                              repetition: .init(type: .none, amount: 0, autoreverses: false))
-    animator.animate(with: timing, to: CALayer(), withValues: [from, to],
-                     keyPath: .opacity)
-    animator.animate(with: timing, to: CALayer(), withValues: [CGPoint(x: from, y: from),
-                                                               CGPoint(x: to, y: to)],
-                     keyPath: .position)
-    animator.animate(with: timing, to: CALayer(), withValues: [CGSize(width: from, height: from),
-                                                               CGSize(width: to, height: to)],
-                     keyPath: .init(rawValue: "bounds.size"))
+    let springCurve = MDMSpringTimingCurve(mass: 1, tension: 1, friction: 1,
+                                           initialVelocity: velocity)
+    let traits = MDMAnimationTraits(delay: 0, duration: 0.7, timingCurve: springCurve)
+    animator.animate(with: traits, values: [from, to],
+                     layer: CALayer(), keyPath: .opacity)
+    animator.animate(with: traits, values: [CGPoint(x: from, y: from),
+                                            CGPoint(x: to, y: to)],
+                     layer: CALayer(), keyPath: .position)
+    animator.animate(with: traits, values: [CGSize(width: from, height: from),
+                                            CGSize(width: to, height: to)],
+                     layer: CALayer(), keyPath: .init(rawValue: "bounds.size"))
   }
 }
 

--- a/tests/unit/InitialVelocityTests.swift
+++ b/tests/unit/InitialVelocityTests.swift
@@ -51,7 +51,7 @@ class InitialVelocityTests: XCTestCase {
     addedAnimations.flatMap { $0 as? CASpringAnimation }.forEach { animation in
       XCTAssertEqual(animation.initialVelocity, 0.5,
                      "from: \(animation.fromValue!), "
-                      + "layer: \(animation.toValue!), "
+                      + "to: \(animation.toValue!), "
                       + "withVelocity: \(velocity)")
     }
   }
@@ -64,7 +64,7 @@ class InitialVelocityTests: XCTestCase {
     addedAnimations.flatMap { $0 as? CASpringAnimation }.forEach { animation in
       XCTAssertEqual(animation.initialVelocity, 0.5,
                      "from: \(animation.fromValue!), "
-                      + "layer: \(animation.toValue!), "
+                      + "to: \(animation.toValue!), "
                       + "withVelocity: \(velocity)")
     }
   }
@@ -77,7 +77,7 @@ class InitialVelocityTests: XCTestCase {
     addedAnimations.flatMap { $0 as? CASpringAnimation }.forEach { animation in
       XCTAssertGreaterThan(animation.initialVelocity, 0,
                            "from: \(animation.fromValue!), "
-                            + "layer: \(animation.toValue!), "
+                            + "to: \(animation.toValue!), "
                             + "withVelocity: \(velocity)")
     }
   }
@@ -90,7 +90,7 @@ class InitialVelocityTests: XCTestCase {
     addedAnimations.flatMap { $0 as? CASpringAnimation }.forEach { animation in
       XCTAssertLessThan(animation.initialVelocity, 0,
                         "from: \(animation.fromValue!), "
-                          + "layer: \(animation.toValue!), "
+                          + "to: \(animation.toValue!), "
                           + "withVelocity: \(velocity)")
     }
   }
@@ -103,7 +103,7 @@ class InitialVelocityTests: XCTestCase {
     addedAnimations.flatMap { $0 as? CASpringAnimation }.forEach { animation in
       XCTAssertGreaterThan(animation.initialVelocity, 0,
                            "from: \(animation.fromValue!), "
-                            + "layer: \(animation.toValue!), "
+                            + "to: \(animation.toValue!), "
                             + "withVelocity: \(velocity)")
     }
   }
@@ -116,7 +116,7 @@ class InitialVelocityTests: XCTestCase {
     addedAnimations.flatMap { $0 as? CASpringAnimation }.forEach { animation in
       XCTAssertLessThan(animation.initialVelocity, 0,
                         "from: \(animation.fromValue!), "
-                          + "layer: \(animation.toValue!), "
+                          + "to: \(animation.toValue!), "
                           + "withVelocity: \(velocity)")
     }
   }
@@ -129,7 +129,7 @@ class InitialVelocityTests: XCTestCase {
     addedAnimations.flatMap { $0 as? CASpringAnimation }.forEach { animation in
       XCTAssertEqual(animation.duration, animation.settlingDuration,
                      "from: \(animation.fromValue!), "
-                      + "layer: \(animation.toValue!), "
+                      + "to: \(animation.toValue!), "
                       + "withVelocity: \(velocity)")
     }
   }

--- a/tests/unit/InitialVelocityTests.swift
+++ b/tests/unit/InitialVelocityTests.swift
@@ -138,12 +138,12 @@ class InitialVelocityTests: XCTestCase {
     let springCurve = MDMSpringTimingCurve(mass: 1, tension: 1, friction: 1,
                                            initialVelocity: velocity)
     let traits = MDMAnimationTraits(delay: 0, duration: 0.7, timingCurve: springCurve)
-    animator.animate(with: traits, values: [from, to],
+    animator.animate(with: traits, between: [from, to],
                      layer: CALayer(), keyPath: .opacity)
-    animator.animate(with: traits, values: [CGPoint(x: from, y: from),
+    animator.animate(with: traits, between: [CGPoint(x: from, y: from),
                                             CGPoint(x: to, y: to)],
                      layer: CALayer(), keyPath: .position)
-    animator.animate(with: traits, values: [CGSize(width: from, height: from),
+    animator.animate(with: traits, between: [CGSize(width: from, height: from),
                                             CGSize(width: to, height: to)],
                      layer: CALayer(), keyPath: .init(rawValue: "bounds.size"))
   }

--- a/tests/unit/InstantAnimationTests.swift
+++ b/tests/unit/InstantAnimationTests.swift
@@ -24,7 +24,6 @@ import MotionAnimator
 class InstantAnimationTests: XCTestCase {
 
   var animator: MotionAnimator!
-  var timing: MotionTiming!
   var view: UIView!
   var addedAnimations: [CAAnimation]!
 
@@ -32,11 +31,6 @@ class InstantAnimationTests: XCTestCase {
     super.setUp()
 
     animator = MotionAnimator()
-
-    timing = MotionTiming(delay: 0,
-                          duration: 0,
-                          curve: .init(type: .instant, data: (0, 0, 0, 0)),
-                          repetition: .init(type: .none, amount: 0, autoreverses: false))
 
     let window = UIWindow()
     window.makeKeyAndVisible()
@@ -61,18 +55,43 @@ class InstantAnimationTests: XCTestCase {
   }
 
   func testDoesNotGenerateImplicitAnimations() {
-    animator.animate(with: timing, to: view.layer, withValues: [1, 0.5], keyPath: .opacity)
+    let traits = MDMAnimationTraits(duration: 0)
+
+    animator.animate(with: traits, values: [1, 0.5],
+                     layer: view.layer, keyPath: .opacity)
 
     XCTAssertNil(view.layer.animationKeys())
     XCTAssertEqual(addedAnimations.count, 0)
   }
 
   func testDoesNotGenerateImplicitAnimationsInUIViewAnimationBlock() {
+    let traits = MDMAnimationTraits(duration: 0)
+
     UIView.animate(withDuration: 0.5) {
-      self.animator.animate(with: self.timing,
-                            to: self.view.layer,
-                            withValues: [1, 0.5],
-                            keyPath: .opacity)
+      self.animator.animate(with: traits, values: [1, 0.5],
+                            layer: self.view.layer, keyPath: .opacity)
+    }
+
+    XCTAssertNil(view.layer.animationKeys())
+    XCTAssertEqual(addedAnimations.count, 0)
+  }
+
+  func testDoesNotGenerateImplicitAnimationsWithNilCurve() {
+    let traits = MDMAnimationTraits(delay: 0, duration: 0.5, timingCurve: nil)
+
+    animator.animate(with: traits, values: [1, 0.5],
+                     layer: view.layer, keyPath: .opacity)
+
+    XCTAssertNil(view.layer.animationKeys())
+    XCTAssertEqual(addedAnimations.count, 0)
+  }
+
+  func testDoesNotGenerateImplicitAnimationsInUIViewAnimationBlockWithNilCurve() {
+    let traits = MDMAnimationTraits(delay: 0, duration: 0.5, timingCurve: nil)
+
+    UIView.animate(withDuration: 0.5) {
+      self.animator.animate(with: traits, values: [1, 0.5],
+                            layer: self.view.layer, keyPath: .opacity)
     }
 
     XCTAssertNil(view.layer.animationKeys())

--- a/tests/unit/InstantAnimationTests.swift
+++ b/tests/unit/InstantAnimationTests.swift
@@ -57,7 +57,7 @@ class InstantAnimationTests: XCTestCase {
   func testDoesNotGenerateImplicitAnimations() {
     let traits = MDMAnimationTraits(duration: 0)
 
-    animator.animate(with: traits, values: [1, 0.5],
+    animator.animate(with: traits, between: [1, 0.5],
                      layer: view.layer, keyPath: .opacity)
 
     XCTAssertNil(view.layer.animationKeys())
@@ -68,7 +68,7 @@ class InstantAnimationTests: XCTestCase {
     let traits = MDMAnimationTraits(duration: 0)
 
     UIView.animate(withDuration: 0.5) {
-      self.animator.animate(with: traits, values: [1, 0.5],
+      self.animator.animate(with: traits, between: [1, 0.5],
                             layer: self.view.layer, keyPath: .opacity)
     }
 
@@ -79,7 +79,7 @@ class InstantAnimationTests: XCTestCase {
   func testDoesNotGenerateImplicitAnimationsWithNilCurve() {
     let traits = MDMAnimationTraits(delay: 0, duration: 0.5, timingCurve: nil)
 
-    animator.animate(with: traits, values: [1, 0.5],
+    animator.animate(with: traits, between: [1, 0.5],
                      layer: view.layer, keyPath: .opacity)
 
     XCTAssertNil(view.layer.animationKeys())
@@ -90,7 +90,7 @@ class InstantAnimationTests: XCTestCase {
     let traits = MDMAnimationTraits(delay: 0, duration: 0.5, timingCurve: nil)
 
     UIView.animate(withDuration: 0.5) {
-      self.animator.animate(with: traits, values: [1, 0.5],
+      self.animator.animate(with: traits, between: [1, 0.5],
                             layer: self.view.layer, keyPath: .opacity)
     }
 

--- a/tests/unit/MotionAnimatorBehavioralTests.swift
+++ b/tests/unit/MotionAnimatorBehavioralTests.swift
@@ -23,7 +23,7 @@ import MotionAnimator
 
 class AnimatorBehavioralTests: XCTestCase {
   var window: UIWindow!
-  var timing: MotionTiming!
+  var traits: MDMAnimationTraits!
 
   var originalImplementation: IMP?
   override func setUp() {
@@ -32,14 +32,11 @@ class AnimatorBehavioralTests: XCTestCase {
     window = UIWindow()
     window.makeKeyAndVisible()
 
-    timing = MotionTiming(delay: 0,
-                          duration: 1,
-                          curve: MotionCurveMakeBezier(p1x: 0, p1y: 0, p2x: 0, p2y: 0),
-                          repetition: .init(type: .none, amount: 0, autoreverses: false))
+    traits = MDMAnimationTraits(duration: 1)
   }
 
   override func tearDown() {
-    timing = nil
+    traits = nil
     window = nil
 
     super.tearDown()
@@ -75,10 +72,8 @@ class AnimatorBehavioralTests: XCTestCase {
 
       let animator = MotionAnimator()
       let initialValue = view.layer.value(forKeyPath: keyPath.rawValue) ?? NSNull()
-      animator.animate(with: timing,
-                       to: view.layer,
-                       withValues: [initialValue, value],
-                       keyPath: keyPath)
+      animator.animate(with: traits, values: [initialValue, value],
+                       layer: view.layer, keyPath: keyPath)
 
       XCTAssertNotNil(view.layer.animationKeys(),
                       "Expected \(keyPath.rawValue) to generate animations with the following "
@@ -99,7 +94,7 @@ class AnimatorBehavioralTests: XCTestCase {
       CATransaction.flush()
 
       let animator = MotionAnimator()
-      animator.animate(with: timing) {
+      animator.animate(with: traits) {
         view.layer.setValue(value, forKeyPath: keyPath.rawValue)
       }
 
@@ -123,10 +118,8 @@ class AnimatorBehavioralTests: XCTestCase {
 
       let animator = MotionAnimator()
       let initialValue = layer.value(forKeyPath: keyPath.rawValue) ?? NSNull()
-      animator.animate(with: timing,
-                       to: layer,
-                       withValues: [initialValue, value],
-                       keyPath: keyPath)
+      animator.animate(with: traits, values: [initialValue, value],
+                       layer: layer, keyPath: keyPath)
 
       XCTAssertNotNil(layer.animationKeys(),
                       "Expected \(keyPath.rawValue) to generate animations with the following "
@@ -147,7 +140,7 @@ class AnimatorBehavioralTests: XCTestCase {
       CATransaction.flush()
 
       let animator = MotionAnimator()
-      animator.animate(with: timing) {
+      animator.animate(with: traits) {
         layer.setValue(value, forKeyPath: keyPath.rawValue)
       }
 

--- a/tests/unit/MotionAnimatorBehavioralTests.swift
+++ b/tests/unit/MotionAnimatorBehavioralTests.swift
@@ -72,7 +72,7 @@ class AnimatorBehavioralTests: XCTestCase {
 
       let animator = MotionAnimator()
       let initialValue = view.layer.value(forKeyPath: keyPath.rawValue) ?? NSNull()
-      animator.animate(with: traits, values: [initialValue, value],
+      animator.animate(with: traits, between: [initialValue, value],
                        layer: view.layer, keyPath: keyPath)
 
       XCTAssertNotNil(view.layer.animationKeys(),
@@ -118,7 +118,7 @@ class AnimatorBehavioralTests: XCTestCase {
 
       let animator = MotionAnimator()
       let initialValue = layer.value(forKeyPath: keyPath.rawValue) ?? NSNull()
-      animator.animate(with: traits, values: [initialValue, value],
+      animator.animate(with: traits, between: [initialValue, value],
                        layer: layer, keyPath: keyPath)
 
       XCTAssertNotNil(layer.animationKeys(),

--- a/tests/unit/MotionAnimatorTests.m
+++ b/tests/unit/MotionAnimatorTests.m
@@ -31,7 +31,7 @@
 
   layer.opacity = 0.5;
 
-  [animator animateWithTraits:traits values:@[ @0, @1 ] layer:layer keyPath:@"opacity"];
+  [animator animateWithTraits:traits between:@[ @0, @1 ] layer:layer keyPath:@"opacity"];
 
   XCTAssertEqual(layer.opacity, 1);
 }
@@ -46,7 +46,7 @@
   layer.opacity = 0.5;
 
   __block BOOL didInvokeCompletion = false;
-  [animator animateWithTraits:traits values:@[ @0, @1 ]
+  [animator animateWithTraits:traits between:@[ @0, @1 ]
                         layer:layer keyPath:@"opacity"
                    completion:^(BOOL didComplete) {
     didInvokeCompletion = true;
@@ -66,7 +66,7 @@
 
   layer.opacity = 0.5;
 
-  [animator animateWithTraits:traits values:@[ @0, @1 ] layer:layer keyPath:@"cornerRadius"];
+  [animator animateWithTraits:traits between:@[ @0, @1 ] layer:layer keyPath:@"cornerRadius"];
 
   XCTAssertEqual(layer.cornerRadius, 0);
 }
@@ -113,7 +113,7 @@
     didAddAnimation = true;
   }];
 
-  [animator animateWithTraits:traits values:@[ @0, @1 ] layer:layer keyPath:keyPath];
+  [animator animateWithTraits:traits between:@[ @0, @1 ] layer:layer keyPath:keyPath];
 
   XCTAssertEqual(layer.cornerRadius, 1);
   XCTAssertTrue(didAddAnimation);
@@ -160,7 +160,7 @@
     didAddAnimation = true;
   }];
 
-  [animator animateWithTraits:traits values:@[ @0, @1 ] layer:layer keyPath:keyPath];
+  [animator animateWithTraits:traits between:@[ @0, @1 ] layer:layer keyPath:keyPath];
 
   XCTAssertEqual(layer.cornerRadius, 1);
   XCTAssertTrue(didAddAnimation);

--- a/tests/unit/MotionAnimatorTests.swift
+++ b/tests/unit/MotionAnimatorTests.swift
@@ -37,7 +37,7 @@ class MotionAnimatorTests: XCTestCase {
     XCTAssertEqual(view.layer.delegate as? UIView, view)
 
     UIView.animate(withDuration: 0.5) {
-      animator.animate(with: traits, values: [0, 1],
+      animator.animate(with: traits, between: [0, 1],
                        layer: view.layer, keyPath: .rotation)
 
       XCTAssertEqual(view.layer.animationKeys()?.count, 1)
@@ -56,7 +56,7 @@ class MotionAnimatorTests: XCTestCase {
     XCTAssertEqual(view.layer.delegate as? UIView, view)
 
     let didComplete = expectation(description: "Did complete")
-    animator.animate(with: traits, values: [0, 1],
+    animator.animate(with: traits, between: [0, 1],
                      layer: view.layer, keyPath: .rotation) { _ in
       didComplete.fulfill()
     }

--- a/tests/unit/MotionAnimatorTests.swift
+++ b/tests/unit/MotionAnimatorTests.swift
@@ -24,52 +24,10 @@ import MotionAnimator
 
 class MotionAnimatorTests: XCTestCase {
 
-  func testAnimatorAPIsCompile() {
-    let animator = MotionAnimator()
-    let timing = MotionTiming(delay: 0,
-                              duration: 1,
-                              curve: MotionCurveMakeBezier(p1x: 0, p1y: 0, p2x: 0, p2y: 0),
-                              repetition: .init(type: .none, amount: 0, autoreverses: false))
-    let layer = CALayer()
-
-    animator.animate(with: timing, to: layer,
-                     withValues: [UIColor.blue, UIColor.red], keyPath: .backgroundColor)
-    animator.animate(with: timing, to: layer,
-                     withValues: [CGRect.zero, CGRect(x: 0, y: 0, width: 100, height: 50)],
-                     keyPath: .bounds)
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .cornerRadius)
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .height)
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .opacity)
-    animator.animate(with: timing, to: layer,
-                     withValues: [CGPoint.zero, CGPoint(x: 1, y: 1)], keyPath: .position)
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .rotation)
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .scale)
-    animator.animate(with: timing, to: layer,
-                     withValues: [CGSize.zero, CGSize(width: 1, height: 1)], keyPath: .shadowOffset)
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .shadowOpacity)
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .shadowRadius)
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .strokeStart)
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .strokeEnd)
-    animator.animate(with: timing, to: layer,
-                     withValues: [CGAffineTransform(rotationAngle: 12),
-                                  CGAffineTransform(rotationAngle: 50)], keyPath: .transform)
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .width)
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .x)
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .y)
-
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .init(rawValue: "bounds.size.width"))
-
-    XCTAssertTrue(true)
-  }
-
   func testAnimatorOnlyUsesSingleNonAdditiveAnimationForKeyPath() {
     let animator = MotionAnimator()
     animator.additive = false
-
-    let timing = MotionTiming(delay: 0,
-                              duration: 1,
-                              curve: MotionCurveMakeBezier(p1x: 0, p1y: 0, p2x: 0, p2y: 0),
-                              repetition: .init(type: .none, amount: 0, autoreverses: false))
+    let traits = MDMAnimationTraits(duration: 1)
 
     let window = UIWindow()
     window.makeKeyAndVisible()
@@ -79,7 +37,8 @@ class MotionAnimatorTests: XCTestCase {
     XCTAssertEqual(view.layer.delegate as? UIView, view)
 
     UIView.animate(withDuration: 0.5) {
-      animator.animate(with: timing, to: view.layer, withValues: [0, 1], keyPath: .rotation)
+      animator.animate(with: traits, values: [0, 1],
+                       layer: view.layer, keyPath: .rotation)
 
       XCTAssertEqual(view.layer.animationKeys()?.count, 1)
     }
@@ -87,11 +46,7 @@ class MotionAnimatorTests: XCTestCase {
 
   func testCompletionCallbackIsExecutedWithZeroDuration() {
     let animator = MotionAnimator()
-
-    let timing = MotionTiming(delay: 0,
-                              duration: 0,
-                              curve: MotionCurveMakeBezier(p1x: 0, p1y: 0, p2x: 0, p2y: 0),
-                              repetition: .init(type: .none, amount: 0, autoreverses: false))
+    let traits = MDMAnimationTraits(duration: 1)
 
     let window = UIWindow()
     window.makeKeyAndVisible()
@@ -101,7 +56,8 @@ class MotionAnimatorTests: XCTestCase {
     XCTAssertEqual(view.layer.delegate as? UIView, view)
 
     let didComplete = expectation(description: "Did complete")
-    animator.animate(with: timing, to: view.layer, withValues: [0, 1], keyPath: .rotation) {
+    animator.animate(with: traits, values: [0, 1],
+                     layer: view.layer, keyPath: .rotation) { _ in
       didComplete.fulfill()
     }
 

--- a/tests/unit/NonAdditiveAnimatorTests.swift
+++ b/tests/unit/NonAdditiveAnimatorTests.swift
@@ -53,7 +53,7 @@ class NonAdditiveAnimationTests: XCTestCase {
   }
 
   func testNumericKeyPathsDontAnimateAdditively() {
-    animator.animate(with: traits, values: [1, 0], layer: view.layer, keyPath: .cornerRadius)
+    animator.animate(with: traits, between: [1, 0], layer: view.layer, keyPath: .cornerRadius)
 
     XCTAssertNotNil(view.layer.animationKeys(),
                     "Expected an animation to be added, but none were found.")
@@ -72,7 +72,7 @@ class NonAdditiveAnimationTests: XCTestCase {
   }
 
   func testSizeKeyPathsDontAnimateAdditively() {
-    animator.animate(with: traits, values: [CGSize(width: 0, height: 0),
+    animator.animate(with: traits, between: [CGSize(width: 0, height: 0),
                                             CGSize(width: 1, height: 2)],
                      layer: view.layer, keyPath: .shadowOffset)
 
@@ -93,7 +93,7 @@ class NonAdditiveAnimationTests: XCTestCase {
   }
 
   func testPositionKeyPathsDontAnimateAdditively() {
-    animator.animate(with: traits, values: [CGPoint(x: 0, y: 0), CGPoint(x: 1, y: 2)],
+    animator.animate(with: traits, between: [CGPoint(x: 0, y: 0), CGPoint(x: 1, y: 2)],
                      layer: view.layer, keyPath: .position)
 
     XCTAssertNotNil(view.layer.animationKeys(),
@@ -113,7 +113,7 @@ class NonAdditiveAnimationTests: XCTestCase {
   }
 
   func testRectKeyPathsDontAnimateAdditively() {
-    animator.animate(with: traits, values: [CGRect(x: 0, y: 0, width: 0, height: 0),
+    animator.animate(with: traits, between: [CGRect(x: 0, y: 0, width: 0, height: 0),
                                             CGRect(x: 0, y: 0, width: 100, height: 50)],
                      layer: view.layer, keyPath: .bounds)
 

--- a/tests/unit/NonAdditiveAnimatorTests.swift
+++ b/tests/unit/NonAdditiveAnimatorTests.swift
@@ -23,7 +23,7 @@ import MotionAnimator
 
 class NonAdditiveAnimationTests: XCTestCase {
   var animator: MotionAnimator!
-  var timing: MotionTiming!
+  var traits: MDMAnimationTraits!
   var view: UIView!
 
   override func setUp() {
@@ -33,10 +33,7 @@ class NonAdditiveAnimationTests: XCTestCase {
 
     animator.additive = false
 
-    timing = MotionTiming(delay: 0,
-                          duration: 1,
-                          curve: MotionCurveMakeBezier(p1x: 0, p1y: 0, p2x: 0, p2y: 0),
-                          repetition: .init(type: .none, amount: 0, autoreverses: false))
+    traits = MDMAnimationTraits(duration: 1)
 
     let window = UIWindow()
     window.makeKeyAndVisible()
@@ -49,14 +46,14 @@ class NonAdditiveAnimationTests: XCTestCase {
 
   override func tearDown() {
     animator = nil
-    timing = nil
+    traits = nil
     view = nil
 
     super.tearDown()
   }
 
   func testNumericKeyPathsDontAnimateAdditively() {
-    animator.animate(with: timing, to: view.layer, withValues: [1, 0], keyPath: .cornerRadius)
+    animator.animate(with: traits, values: [1, 0], layer: view.layer, keyPath: .cornerRadius)
 
     XCTAssertNotNil(view.layer.animationKeys(),
                     "Expected an animation to be added, but none were found.")
@@ -75,9 +72,9 @@ class NonAdditiveAnimationTests: XCTestCase {
   }
 
   func testSizeKeyPathsDontAnimateAdditively() {
-    animator.animate(with: timing, to: view.layer,
-                     withValues: [CGSize(width: 0, height: 0),
-                                  CGSize(width: 1, height: 2)], keyPath: .shadowOffset)
+    animator.animate(with: traits, values: [CGSize(width: 0, height: 0),
+                                            CGSize(width: 1, height: 2)],
+                     layer: view.layer, keyPath: .shadowOffset)
 
     XCTAssertNotNil(view.layer.animationKeys(),
                     "Expected an animation to be added, but none were found.")
@@ -96,9 +93,8 @@ class NonAdditiveAnimationTests: XCTestCase {
   }
 
   func testPositionKeyPathsDontAnimateAdditively() {
-    animator.animate(with: timing, to: view.layer,
-                     withValues: [CGPoint(x: 0, y: 0),
-                                  CGPoint(x: 1, y: 2)], keyPath: .position)
+    animator.animate(with: traits, values: [CGPoint(x: 0, y: 0), CGPoint(x: 1, y: 2)],
+                     layer: view.layer, keyPath: .position)
 
     XCTAssertNotNil(view.layer.animationKeys(),
                     "Expected an animation to be added, but none were found.")
@@ -117,9 +113,9 @@ class NonAdditiveAnimationTests: XCTestCase {
   }
 
   func testRectKeyPathsDontAnimateAdditively() {
-    animator.animate(with: timing, to: view.layer,
-                     withValues: [CGRect(x: 0, y: 0, width: 0, height: 0),
-                                  CGRect(x: 0, y: 0, width: 100, height: 50)], keyPath: .bounds)
+    animator.animate(with: traits, values: [CGRect(x: 0, y: 0, width: 0, height: 0),
+                                            CGRect(x: 0, y: 0, width: 100, height: 50)],
+                     layer: view.layer, keyPath: .bounds)
 
     XCTAssertNotNil(view.layer.animationKeys(),
                     "Expected an animation to be added, but none were found.")

--- a/tests/unit/TimeScaleFactorTests.swift
+++ b/tests/unit/TimeScaleFactorTests.swift
@@ -49,7 +49,7 @@ class TimeScaleFactorTests: XCTestCase {
   }
 
   func testDefaultTimeScaleFactorDoesNotModifyDuration() {
-    animator.animate(with: traits, values: [0, 1], layer: layer, keyPath: .rotation)
+    animator.animate(with: traits, between: [0, 1], layer: layer, keyPath: .rotation)
 
     XCTAssertEqual(addedAnimations.count, 1)
     let animation = addedAnimations.last!
@@ -59,7 +59,7 @@ class TimeScaleFactorTests: XCTestCase {
   func testExplicitTimeScaleFactorChangesDuration() {
     animator.timeScaleFactor = 0.5
 
-    animator.animate(with: traits, values: [0, 1], layer: layer, keyPath: .rotation)
+    animator.animate(with: traits, between: [0, 1], layer: layer, keyPath: .rotation)
 
     XCTAssertEqual(addedAnimations.count, 1)
     let animation = addedAnimations.last!
@@ -70,7 +70,7 @@ class TimeScaleFactorTests: XCTestCase {
     CATransaction.begin()
     CATransaction.mdm_setTimeScaleFactor(0.5)
 
-    animator.animate(with: traits, values: [0, 1], layer: layer, keyPath: .rotation)
+    animator.animate(with: traits, between: [0, 1], layer: layer, keyPath: .rotation)
     CATransaction.commit()
 
     XCTAssertEqual(addedAnimations.count, 1)
@@ -84,7 +84,7 @@ class TimeScaleFactorTests: XCTestCase {
     CATransaction.begin()
     CATransaction.mdm_setTimeScaleFactor(0.5)
 
-    animator.animate(with: traits, values: [0, 1], layer: layer, keyPath: .rotation)
+    animator.animate(with: traits, between: [0, 1], layer: layer, keyPath: .rotation)
 
     CATransaction.commit()
 
@@ -100,7 +100,7 @@ class TimeScaleFactorTests: XCTestCase {
     CATransaction.mdm_setTimeScaleFactor(0.5)
     CATransaction.mdm_setTimeScaleFactor(nil)
 
-    animator.animate(with: traits, values: [0, 1], layer: layer, keyPath: .rotation)
+    animator.animate(with: traits, between: [0, 1], layer: layer, keyPath: .rotation)
 
     CATransaction.commit()
 

--- a/tests/unit/TimeScaleFactorTests.swift
+++ b/tests/unit/TimeScaleFactorTests.swift
@@ -23,10 +23,7 @@ import MotionAnimator
 
 class TimeScaleFactorTests: XCTestCase {
 
-  let timing = MotionTiming(delay: 0,
-                            duration: 1,
-                            curve: MotionCurveMakeBezier(p1x: 0, p1y: 0, p2x: 0, p2y: 0),
-                            repetition: .init(type: .none, amount: 0, autoreverses: false))
+  let traits = MDMAnimationTraits(duration: 1)
   var layer: CALayer!
   var addedAnimations: [CAAnimation]!
   var animator: MotionAnimator!
@@ -52,7 +49,7 @@ class TimeScaleFactorTests: XCTestCase {
   }
 
   func testDefaultTimeScaleFactorDoesNotModifyDuration() {
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .rotation)
+    animator.animate(with: traits, values: [0, 1], layer: layer, keyPath: .rotation)
 
     XCTAssertEqual(addedAnimations.count, 1)
     let animation = addedAnimations.last!
@@ -62,23 +59,23 @@ class TimeScaleFactorTests: XCTestCase {
   func testExplicitTimeScaleFactorChangesDuration() {
     animator.timeScaleFactor = 0.5
 
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .rotation)
+    animator.animate(with: traits, values: [0, 1], layer: layer, keyPath: .rotation)
 
     XCTAssertEqual(addedAnimations.count, 1)
     let animation = addedAnimations.last!
-    XCTAssertEqual(animation.duration, timing.duration * 0.5)
+    XCTAssertEqual(animation.duration, traits.duration * 0.5)
   }
 
   func testTransactionTimeScaleFactorChangesDuration() {
     CATransaction.begin()
     CATransaction.mdm_setTimeScaleFactor(0.5)
 
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .rotation)
+    animator.animate(with: traits, values: [0, 1], layer: layer, keyPath: .rotation)
     CATransaction.commit()
 
     XCTAssertEqual(addedAnimations.count, 1)
     let animation = addedAnimations.last!
-    XCTAssertEqual(animation.duration, timing.duration * 0.5)
+    XCTAssertEqual(animation.duration, traits.duration * 0.5)
   }
 
   func testTransactionTimeScaleFactorOverridesAnimatorTimeScaleFactor() {
@@ -87,13 +84,13 @@ class TimeScaleFactorTests: XCTestCase {
     CATransaction.begin()
     CATransaction.mdm_setTimeScaleFactor(0.5)
 
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .rotation)
+    animator.animate(with: traits, values: [0, 1], layer: layer, keyPath: .rotation)
 
     CATransaction.commit()
 
     XCTAssertEqual(addedAnimations.count, 1)
     let animation = addedAnimations.last!
-    XCTAssertEqual(animation.duration, timing.duration * 0.5)
+    XCTAssertEqual(animation.duration, traits.duration * 0.5)
   }
 
   func testNilTransactionTimeScaleFactorUsesAnimatorTimeScaleFactor() {
@@ -103,12 +100,12 @@ class TimeScaleFactorTests: XCTestCase {
     CATransaction.mdm_setTimeScaleFactor(0.5)
     CATransaction.mdm_setTimeScaleFactor(nil)
 
-    animator.animate(with: timing, to: layer, withValues: [0, 1], keyPath: .rotation)
+    animator.animate(with: traits, values: [0, 1], layer: layer, keyPath: .rotation)
 
     CATransaction.commit()
 
     XCTAssertEqual(addedAnimations.count, 1)
     let animation = addedAnimations.last!
-    XCTAssertEqual(animation.duration, timing.duration * 2)
+    XCTAssertEqual(animation.duration, traits.duration * 2)
   }
 }


### PR DESCRIPTION
This change introduces new APIs that are compatible with the new interchange format introduced in MotionInterchange [v1.5.0](https://github.com/material-motion/motion-interchange-objc/releases/tag/v1.5.0). The API arguments have also been reordered to be somewhat more intuitive.

Note that this is not intended to be a breaking change.