### PR TITLE
Add UIKit equivalent APIs for animating implicitly.

### DIFF
--- a/examples/apps/Catalog/MotionAnimatorCatalog.xcodeproj/project.pbxproj
+++ b/examples/apps/Catalog/MotionAnimatorCatalog.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		667A3F4C1DEE269400CB3A99 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 667A3F4A1DEE269400CB3A99 /* LaunchScreen.storyboard */; };
 		667A3F541DEE273000CB3A99 /* TableOfContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 667A3F531DEE273000CB3A99 /* TableOfContents.swift */; };
 		6687264A1EF04B4C00113675 /* MotionAnimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668726491EF04B4C00113675 /* MotionAnimatorTests.swift */; };
+		668819FA1FE2EB36003A9420 /* UIKitEquivalencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668819F91FE2EB36003A9420 /* UIKitEquivalencyTests.swift */; };
 		669B6CA91FD0547100B80B76 /* MotionAnimatorBehavioralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669B6CA81FD0547100B80B76 /* MotionAnimatorBehavioralTests.swift */; };
 		66A6A6681FBA158000DE54CB /* AnimationRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66A6A6671FBA158000DE54CB /* AnimationRemovalTests.swift */; };
 		66BF5A8F1FB0E4CB00E864F6 /* ImplicitAnimationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66BF5A8E1FB0E4CB00E864F6 /* ImplicitAnimationTests.swift */; };
@@ -78,6 +79,7 @@
 		667A3F4D1DEE269400CB3A99 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		667A3F531DEE273000CB3A99 /* TableOfContents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableOfContents.swift; sourceTree = "<group>"; };
 		668726491EF04B4C00113675 /* MotionAnimatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionAnimatorTests.swift; sourceTree = "<group>"; };
+		668819F91FE2EB36003A9420 /* UIKitEquivalencyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIKitEquivalencyTests.swift; sourceTree = "<group>"; };
 		669B6CA81FD0547100B80B76 /* MotionAnimatorBehavioralTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionAnimatorBehavioralTests.swift; sourceTree = "<group>"; };
 		66A6A6671FBA158000DE54CB /* AnimationRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationRemovalTests.swift; sourceTree = "<group>"; };
 		66BF5A8E1FB0E4CB00E864F6 /* ImplicitAnimationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplicitAnimationTests.swift; sourceTree = "<group>"; };
@@ -243,6 +245,7 @@
 				664F59951FCDB2E5002EC56D /* QuartzCoreBehavioralTests.swift */,
 				660636011FACC24300C3DFB8 /* TimeScaleFactorTests.swift */,
 				664F59931FCCE27E002EC56D /* UIKitBehavioralTests.swift */,
+				668819F91FE2EB36003A9420 /* UIKitEquivalencyTests.swift */,
 			);
 			path = unit;
 			sourceTree = "<group>";
@@ -533,6 +536,7 @@
 				664F59981FCE5CE2002EC56D /* BeginFromCurrentStateTests.swift in Sources */,
 				66FD99FA1EE9FBBE00C53A82 /* MotionAnimatorTests.m in Sources */,
 				669B6CA91FD0547100B80B76 /* MotionAnimatorBehavioralTests.swift in Sources */,
+				668819FA1FE2EB36003A9420 /* UIKitEquivalencyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/MDMMotionAnimator.h
+++ b/src/MDMMotionAnimator.h
@@ -99,13 +99,13 @@ NS_SWIFT_NAME(MotionAnimator)
  @param completion A block object to be executed when the animation ends or is removed from the
  animation hierarchy. If the duration of the animation is 0, this block is executed immediately.
  The block is escaping and will be released once the animations have completed. The provided
- didComplete argument is currently always YES.
+ `finished` argument is currently always YES.
  */
 - (void)animateWithTraits:(nonnull MDMAnimationTraits *)traits
                   between:(nonnull NSArray *)values
                     layer:(nonnull CALayer *)layer
                   keyPath:(nonnull MDMAnimatableKeyPath)keyPath
-               completion:(nullable void(^)(BOOL didComplete))completion;
+               completion:(nullable void(^)(BOOL finished))completion;
 
 /**
  If enabled, explicitly-provided values will be reversed before animating.
@@ -140,11 +140,11 @@ NS_SWIFT_NAME(MotionAnimator)
  @param completion A block object to be executed once the animation sequence ends or it has been
  removed from the animation hierarchy. If the duration of the animation is 0, this block is executed
  immediately. The block is escaping and will be released once the animation sequence has completed. The provided
- didComplete argument is currently always YES.
+ `finished` argument is currently always YES.
  */
 - (void)animateWithTraits:(nonnull MDMAnimationTraits *)traits
                animations:(nonnull void (^)(void))animations
-               completion:(nullable void(^)(BOOL didComplete))completion;
+               completion:(nullable void(^)(BOOL finished))completion;
 
 #pragma mark - Managing active animations
 
@@ -164,6 +164,130 @@ NS_SWIFT_NAME(MotionAnimator)
  in-flight animations are stopped at their current on-screen position.
  */
 - (void)stopAllAnimations;
+
+@end
+
+@interface MDMMotionAnimator (UIKitEquivalency)
+
+/**
+ Similar to the UIKit method of the same name with some intentional differences in behavior.
+
+ This API does not disable user interaction during animations, unlike the default behavior of
+ UIView's similar API.
+
+ Like the UIKit API, this method performs the specified animations immediately using the
+ UIViewAnimationOptionCurveEaseInOut animation option.
+ 
+ @param duration From UIKit's documentation: "The total duration of the animations, measured in
+ seconds. If you specify a negative value or 0, the changes are made without animating them."
+ @param animations From UIKit's documentation: "A block object containing the changes to commit to
+ the views. This is where you programmatically change any animatable properties of the views in your
+ view hierarchy. This block takes no parameters and has no return value. This parameter must not be
+ NULL." Supports animating additional CALayer properties beyond what UIView's similar API supports.
+ See MDMAnimatableKeyPaths for a full list of implicilty animatable CALayer properties.
+ */
++ (void)animateWithDuration:(NSTimeInterval)duration
+                 animations:(void (^ __nonnull)(void))animations;
+
+/**
+ Similar to the UIKit method of the same name with some intentional differences in behavior.
+
+ This API does not disable user interaction during animations, unlike the default behavior of
+ UIView's similar API.
+
+ Like the UIKit API, this method performs the specified animations immediately using the
+ UIViewAnimationOptionCurveEaseInOut animation option.
+
+ @param duration From UIKit's documentation: "The total duration of the animations, measured in
+ seconds. If you specify a negative value or 0, the changes are made without animating them."
+ @param animations From UIKit's documentation: "A block object containing the changes to commit to
+ the views. This is where you programmatically change any animatable properties of the views in your
+ view hierarchy. This block takes no parameters and has no return value. This parameter must not be
+ NULL." Supports animating additional CALayer properties beyond what UIView's similar API supports.
+ See MDMAnimatableKeyPaths for a full list of implicilty animatable CALayer properties.
+ @param completion From UIKit's documentation: "A block object to be executed when the animation
+ sequence ends. This block has no return value and takes a single Boolean argument that indicates
+ whether or not the animations actually finished before the completion handler was called." Unlike
+ UIKit's API, if the duration of the animation is 0, this block is performed immediately. This
+ parameter may be NULL.
+ */
++ (void)animateWithDuration:(NSTimeInterval)duration
+                 animations:(void (^ __nonnull)(void))animations
+                 completion:(void (^ __nullable)(BOOL finished))completion;
+
+/**
+ Similar to the UIKit method of the same name with some intentional differences in behavior.
+
+ This API does not disable user interaction during animations, unlike the default behavior of
+ UIView's similar API.
+
+ Like the UIKit API, this method performs the specified animations immediately.
+
+ The only options that are presently supported are the UIViewAnimationOptionCurve flags.
+
+ @param duration From UIKit's documentation: "The total duration of the animations, measured in
+ seconds. If you specify a negative value or 0, the changes are made without animating them."
+ @param delay From UIKit's documentation: "The amount of time (measured in seconds) to wait before
+ beginning the animations. Specify a value of 0 to begin the animations immediately."
+ @param options From UIKit's documentation: "A mask of options indicating how you want to perform
+ the animations. For a list of valid constants, see UIViewAnimationOptions." Only the
+ UIViewAnimationOptionCurve flags are supported presently.
+ @param animations From UIKit's documentation: "A block object containing the changes to commit to
+ the views. This is where you programmatically change any animatable properties of the views in your
+ view hierarchy. This block takes no parameters and has no return value. This parameter must not be
+ NULL." Supports animating additional CALayer properties beyond what UIView's similar API supports.
+ See MDMAnimatableKeyPaths for a full list of implicilty animatable CALayer properties.
+ @param completion From UIKit's documentation: "A block object to be executed when the animation
+ sequence ends. This block has no return value and takes a single Boolean argument that indicates
+ whether or not the animations actually finished before the completion handler was called." Unlike
+ UIKit's API, if the duration of the animation is 0, this block is performed immediately. This
+ parameter may be NULL.
+ */
++ (void)animateWithDuration:(NSTimeInterval)duration
+                      delay:(NSTimeInterval)delay
+                    options:(UIViewAnimationOptions)options
+                 animations:(void (^ __nonnull)(void))animations
+                 completion:(void (^ __nullable)(BOOL finished))completion;
+
+/**
+ Similar to the UIKit method of the same name with some intentional differences in behavior.
+
+ This API does not disable user interaction during animations, unlike the default behavior of
+ UIView's similar API.
+
+ Like the UIKit API, this method performs the specified animations immediately.
+
+ @param duration From UIKit's documentation: "The total duration of the animations, measured in
+ seconds. If you specify a negative value or 0, the changes are made without animating them."
+ @param delay From UIKit's documentation: "The amount of time (measured in seconds) to wait before
+ beginning the animations. Specify a value of 0 to begin the animations immediately."
+ @param options Ignored.
+ @param dampingRatio From UIKit's documentation: "The damping ratio for the spring animation as it
+ approaches its quiescent state. To smoothly decelerate the animation without oscillation, use a
+ value of 1. Employ a damping ratio closer to zero to increase oscillation."
+ @param velocity From UIKit's documentation: "The initial spring velocity. For smooth start to the
+ animation, match this value to the view’s velocity as it was prior to attachment.
+ A value of 1 corresponds to the total animation distance traversed in one second. For example, if
+ the total animation distance is 200 points and you want the start of the animation to match a view
+ velocity of 100 pt/s, use a value of 0.5."
+ @param animations From UIKit's documentation: "A block object containing the changes to commit to
+ the views. This is where you programmatically change any animatable properties of the views in your
+ view hierarchy. This block takes no parameters and has no return value. This parameter must not be
+ NULL." Supports animating additional CALayer properties beyond what UIView's similar API supports.
+ See MDMAnimatableKeyPaths for a full list of implicilty animatable CALayer properties.
+ @param completion From UIKit's documentation: "A block object to be executed when the animation
+ sequence ends. This block has no return value and takes a single Boolean argument that indicates
+ whether or not the animations actually finished before the completion handler was called." Unlike
+ UIKit's API, if the duration of the animation is 0, this block is performed immediately. This
+ parameter may be NULL.
+ */
++ (void)animateWithDuration:(NSTimeInterval)duration
+                      delay:(NSTimeInterval)delay
+     usingSpringWithDamping:(CGFloat)dampingRatio
+      initialSpringVelocity:(CGFloat)velocity
+                    options:(UIViewAnimationOptions)options
+                 animations:(void (^ __nonnull)(void))animations
+                 completion:(void (^ __nullable)(BOOL finished))completion;
 
 @end
 

--- a/src/MDMMotionAnimator.h
+++ b/src/MDMMotionAnimator.h
@@ -139,8 +139,8 @@ NS_SWIFT_NAME(MotionAnimator)
  non-escaping.
  @param completion A block object to be executed once the animation sequence ends or it has been
  removed from the animation hierarchy. If the duration of the animation is 0, this block is executed
- immediately. The block is escaping and will be released once the animation sequence has completed. The provided
- `finished` argument is currently always YES.
+ immediately. The block is escaping and will be released once the animation sequence has completed.
+ The provided `finished` argument is currently always YES.
  */
 - (void)animateWithTraits:(nonnull MDMAnimationTraits *)traits
                animations:(nonnull void (^)(void))animations
@@ -178,13 +178,17 @@ NS_SWIFT_NAME(MotionAnimator)
  Like the UIKit API, this method performs the specified animations immediately using the
  UIViewAnimationOptionCurveEaseInOut animation option.
  
- @param duration From UIKit's documentation: "The total duration of the animations, measured in
- seconds. If you specify a negative value or 0, the changes are made without animating them."
+ @param duration   From UIKit's documentation: "The total duration of the animations, measured in
+                   seconds. If you specify a negative value or 0, the changes are made without
+                   animating them."
+
  @param animations From UIKit's documentation: "A block object containing the changes to commit to
- the views. This is where you programmatically change any animatable properties of the views in your
- view hierarchy. This block takes no parameters and has no return value. This parameter must not be
- NULL." Supports animating additional CALayer properties beyond what UIView's similar API supports.
- See MDMAnimatableKeyPaths for a full list of implicilty animatable CALayer properties.
+                   the views. This is where you programmatically change any animatable properties of
+                   the views in your view hierarchy. This block takes no parameters and has no
+                   return value. This parameter must not be NULL." Supports animating additional
+                   CALayer properties beyond what UIView's similar API supports. See
+                   MDMAnimatableKeyPaths for a full list of implicilty animatable CALayer
+                   properties.
  */
 + (void)animateWithDuration:(NSTimeInterval)duration
                  animations:(void (^ __nonnull)(void))animations;
@@ -198,18 +202,23 @@ NS_SWIFT_NAME(MotionAnimator)
  Like the UIKit API, this method performs the specified animations immediately using the
  UIViewAnimationOptionCurveEaseInOut animation option.
 
- @param duration From UIKit's documentation: "The total duration of the animations, measured in
- seconds. If you specify a negative value or 0, the changes are made without animating them."
+ @param duration   From UIKit's documentation: "The total duration of the animations, measured in
+                   seconds. If you specify a negative value or 0, the changes are made without
+                   animating them."
+
  @param animations From UIKit's documentation: "A block object containing the changes to commit to
- the views. This is where you programmatically change any animatable properties of the views in your
- view hierarchy. This block takes no parameters and has no return value. This parameter must not be
- NULL." Supports animating additional CALayer properties beyond what UIView's similar API supports.
- See MDMAnimatableKeyPaths for a full list of implicilty animatable CALayer properties.
+                   the views. This is where you programmatically change any animatable properties of
+                   the views in your view hierarchy. This block takes no parameters and has no
+                   return value. This parameter must not be NULL." Supports animating additional
+                   CALayer properties beyond what UIView's similar API supports. See
+                   MDMAnimatableKeyPaths for a full list of implicilty animatable CALayer
+                   properties.
+
  @param completion From UIKit's documentation: "A block object to be executed when the animation
- sequence ends. This block has no return value and takes a single Boolean argument that indicates
- whether or not the animations actually finished before the completion handler was called." Unlike
- UIKit's API, if the duration of the animation is 0, this block is performed immediately. This
- parameter may be NULL.
+                   sequence ends. This block has no return value and takes a single Boolean argument
+                   that indicates whether or not the animations actually finished before the
+                   completion handler was called." Unlike UIKit's API, if the duration of the
+                   animation is 0, this block is performed immediately. This parameter may be NULL.
  */
 + (void)animateWithDuration:(NSTimeInterval)duration
                  animations:(void (^ __nonnull)(void))animations
@@ -225,23 +234,31 @@ NS_SWIFT_NAME(MotionAnimator)
 
  The only options that are presently supported are the UIViewAnimationOptionCurve flags.
 
- @param duration From UIKit's documentation: "The total duration of the animations, measured in
- seconds. If you specify a negative value or 0, the changes are made without animating them."
- @param delay From UIKit's documentation: "The amount of time (measured in seconds) to wait before
- beginning the animations. Specify a value of 0 to begin the animations immediately."
- @param options From UIKit's documentation: "A mask of options indicating how you want to perform
- the animations. For a list of valid constants, see UIViewAnimationOptions." Only the
- UIViewAnimationOptionCurve flags are supported presently.
+ @param duration   From UIKit's documentation: "The total duration of the animations, measured in
+                   seconds. If you specify a negative value or 0, the changes are made without
+                   animating them."
+
+ @param delay      From UIKit's documentation: "The amount of time (measured in seconds) to wait
+                   before beginning the animations. Specify a value of 0 to begin the animations
+                   immediately."
+
+ @param options    From UIKit's documentation: "A mask of options indicating how you want to perform
+                   the animations. For a list of valid constants, see UIViewAnimationOptions." Only
+                   the UIViewAnimationOptionCurve flags are supported presently.
+
  @param animations From UIKit's documentation: "A block object containing the changes to commit to
- the views. This is where you programmatically change any animatable properties of the views in your
- view hierarchy. This block takes no parameters and has no return value. This parameter must not be
- NULL." Supports animating additional CALayer properties beyond what UIView's similar API supports.
- See MDMAnimatableKeyPaths for a full list of implicilty animatable CALayer properties.
+                   the views. This is where you programmatically change any animatable properties of
+                   the views in your view hierarchy. This block takes no parameters and has no
+                   return value. This parameter must not be NULL." Supports animating additional
+                   CALayer properties beyond what UIView's similar API supports. See
+                   MDMAnimatableKeyPaths for a full list of implicilty animatable CALayer
+                   properties.
+
  @param completion From UIKit's documentation: "A block object to be executed when the animation
- sequence ends. This block has no return value and takes a single Boolean argument that indicates
- whether or not the animations actually finished before the completion handler was called." Unlike
- UIKit's API, if the duration of the animation is 0, this block is performed immediately. This
- parameter may be NULL.
+                   sequence ends. This block has no return value and takes a single Boolean argument
+                   that indicates whether or not the animations actually finished before the
+                   completion handler was called." Unlike UIKit's API, if the duration of the
+                   animation is 0, this block is performed immediately. This parameter may be NULL.
  */
 + (void)animateWithDuration:(NSTimeInterval)duration
                       delay:(NSTimeInterval)delay
@@ -257,29 +274,42 @@ NS_SWIFT_NAME(MotionAnimator)
 
  Like the UIKit API, this method performs the specified animations immediately.
 
- @param duration From UIKit's documentation: "The total duration of the animations, measured in
- seconds. If you specify a negative value or 0, the changes are made without animating them."
- @param delay From UIKit's documentation: "The amount of time (measured in seconds) to wait before
- beginning the animations. Specify a value of 0 to begin the animations immediately."
- @param options Ignored.
+ @param duration     From UIKit's documentation: "The total duration of the animations, measured in
+                     seconds. If you specify a negative value or 0, the changes are made without
+                     animating them."
+
+ @param delay        From UIKit's documentation: "The amount of time (measured in seconds) to wait
+                     before beginning the animations. Specify a value of 0 to begin the animations
+                     immediately."
+
+ @param options      Ignored.
+
  @param dampingRatio From UIKit's documentation: "The damping ratio for the spring animation as it
- approaches its quiescent state. To smoothly decelerate the animation without oscillation, use a
- value of 1. Employ a damping ratio closer to zero to increase oscillation."
- @param velocity From UIKit's documentation: "The initial spring velocity. For smooth start to the
- animation, match this value to the view’s velocity as it was prior to attachment.
- A value of 1 corresponds to the total animation distance traversed in one second. For example, if
- the total animation distance is 200 points and you want the start of the animation to match a view
- velocity of 100 pt/s, use a value of 0.5."
- @param animations From UIKit's documentation: "A block object containing the changes to commit to
- the views. This is where you programmatically change any animatable properties of the views in your
- view hierarchy. This block takes no parameters and has no return value. This parameter must not be
- NULL." Supports animating additional CALayer properties beyond what UIView's similar API supports.
- See MDMAnimatableKeyPaths for a full list of implicilty animatable CALayer properties.
- @param completion From UIKit's documentation: "A block object to be executed when the animation
- sequence ends. This block has no return value and takes a single Boolean argument that indicates
- whether or not the animations actually finished before the completion handler was called." Unlike
- UIKit's API, if the duration of the animation is 0, this block is performed immediately. This
- parameter may be NULL.
+                     approaches its quiescent state. To smoothly decelerate the animation without
+                     oscillation, use a value of 1. Employ a damping ratio closer to zero to
+                     increase oscillation."
+
+ @param velocity     From UIKit's documentation: "The initial spring velocity. For smooth start to
+                     the animation, match this value to the view’s velocity as it was prior to
+                     attachment. A value of 1 corresponds to the total animation distance traversed
+                     in one second. For example, if the total animation distance is 200 points and
+                     you want the start of the animation to match a view velocity of 100 pt/s, use a
+                     value of 0.5."
+
+ @param animations   From UIKit's documentation: "A block object containing the changes to commit to
+                     the views. This is where you programmatically change any animatable properties
+                     of the views in your view hierarchy. This block takes no parameters and has no
+                     return value. This parameter must not be NULL." Supports animating additional
+                     CALayer properties beyond what UIView's similar API supports. See
+                     MDMAnimatableKeyPaths for a full list of implicilty animatable CALayer
+                     properties.
+
+ @param completion   From UIKit's documentation: "A block object to be executed when the animation
+                     sequence ends. This block has no return value and takes a single Boolean
+                     argument that indicates whether or not the animations actually finished before
+                     the completion handler was called." Unlike UIKit's API, if the duration of the
+                     animation is 0, this block is performed immediately. This parameter may be
+                     NULL.
  */
 + (void)animateWithDuration:(NSTimeInterval)duration
                       delay:(NSTimeInterval)delay

--- a/src/MDMMotionAnimator.h
+++ b/src/MDMMotionAnimator.h
@@ -185,10 +185,10 @@ NS_SWIFT_NAME(MotionAnimator)
  @param animations From UIKit's documentation: "A block object containing the changes to commit to
                    the views. This is where you programmatically change any animatable properties of
                    the views in your view hierarchy. This block takes no parameters and has no
-                   return value. This parameter must not be NULL." Supports animating additional
-                   CALayer properties beyond what UIView's similar API supports. See
-                   MDMAnimatableKeyPaths for a full list of implicilty animatable CALayer
-                   properties.
+                   return value. This parameter must not be NULL."
+                   Supports animating additional CALayer properties beyond what UIView's similar API
+                   supports. See MDMAnimatableKeyPaths for a full list of implicilty animatable
+                   CALayer properties.
  */
 + (void)animateWithDuration:(NSTimeInterval)duration
                  animations:(void (^ __nonnull)(void))animations;
@@ -209,16 +209,17 @@ NS_SWIFT_NAME(MotionAnimator)
  @param animations From UIKit's documentation: "A block object containing the changes to commit to
                    the views. This is where you programmatically change any animatable properties of
                    the views in your view hierarchy. This block takes no parameters and has no
-                   return value. This parameter must not be NULL." Supports animating additional
-                   CALayer properties beyond what UIView's similar API supports. See
-                   MDMAnimatableKeyPaths for a full list of implicilty animatable CALayer
-                   properties.
+                   return value. This parameter must not be NULL."
+                   Supports animating additional CALayer properties beyond what UIView's similar API
+                   supports. See MDMAnimatableKeyPaths for a full list of implicilty animatable
+                   CALayer properties.
 
  @param completion From UIKit's documentation: "A block object to be executed when the animation
                    sequence ends. This block has no return value and takes a single Boolean argument
                    that indicates whether or not the animations actually finished before the
-                   completion handler was called." Unlike UIKit's API, if the duration of the
-                   animation is 0, this block is performed immediately. This parameter may be NULL.
+                   completion handler was called."
+                   Unlike UIKit's API, if the duration of the animation is 0, this block is
+                   performed immediately. This parameter may be NULL.
  */
 + (void)animateWithDuration:(NSTimeInterval)duration
                  animations:(void (^ __nonnull)(void))animations
@@ -249,16 +250,17 @@ NS_SWIFT_NAME(MotionAnimator)
  @param animations From UIKit's documentation: "A block object containing the changes to commit to
                    the views. This is where you programmatically change any animatable properties of
                    the views in your view hierarchy. This block takes no parameters and has no
-                   return value. This parameter must not be NULL." Supports animating additional
-                   CALayer properties beyond what UIView's similar API supports. See
-                   MDMAnimatableKeyPaths for a full list of implicilty animatable CALayer
-                   properties.
+                   return value. This parameter must not be NULL."
+                   Supports animating additional CALayer properties beyond what UIView's similar API
+                   supports. See MDMAnimatableKeyPaths for a full list of implicilty animatable
+                   CALayer properties.
 
  @param completion From UIKit's documentation: "A block object to be executed when the animation
                    sequence ends. This block has no return value and takes a single Boolean argument
                    that indicates whether or not the animations actually finished before the
-                   completion handler was called." Unlike UIKit's API, if the duration of the
-                   animation is 0, this block is performed immediately. This parameter may be NULL.
+                   completion handler was called."
+                   Unlike UIKit's API, if the duration of the animation is 0, this block is
+                   performed immediately. This parameter may be NULL.
  */
 + (void)animateWithDuration:(NSTimeInterval)duration
                       delay:(NSTimeInterval)delay
@@ -299,17 +301,17 @@ NS_SWIFT_NAME(MotionAnimator)
  @param animations   From UIKit's documentation: "A block object containing the changes to commit to
                      the views. This is where you programmatically change any animatable properties
                      of the views in your view hierarchy. This block takes no parameters and has no
-                     return value. This parameter must not be NULL." Supports animating additional
-                     CALayer properties beyond what UIView's similar API supports. See
-                     MDMAnimatableKeyPaths for a full list of implicilty animatable CALayer
-                     properties.
+                     return value. This parameter must not be NULL."
+                     Supports animating additional CALayer properties beyond what UIView's similar
+                     API supports. See MDMAnimatableKeyPaths for a full list of implicilty
+                     animatable CALayer properties.
 
  @param completion   From UIKit's documentation: "A block object to be executed when the animation
                      sequence ends. This block has no return value and takes a single Boolean
                      argument that indicates whether or not the animations actually finished before
-                     the completion handler was called." Unlike UIKit's API, if the duration of the
-                     animation is 0, this block is performed immediately. This parameter may be
-                     NULL.
+                     the completion handler was called."
+                     Unlike UIKit's API, if the duration of the animation is 0, this block is
+                     performed immediately. This parameter may be NULL.
  */
 + (void)animateWithDuration:(NSTimeInterval)duration
                       delay:(NSTimeInterval)delay

--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -245,7 +245,7 @@
   traits.timingCurve =
       [[MDMSpringTimingCurveGenerator alloc] initWithDuration:duration
                                                  dampingRatio:dampingRatio
-                                              initialVelocity:velocity];
+                                              initialVelocity:velocity].springTimingCurve;
   [animator animateWithTraits:traits animations:animations completion:completion];
 }
 

--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -197,6 +197,58 @@
   [_registrar removeAllAnimations];
 }
 
+#pragma mark - UIKit equivalency
+
++ (void)animateWithDuration:(NSTimeInterval)duration
+                 animations:(void (^ __nonnull)(void))animations {
+  [self animateWithDuration:duration animations:animations completion:nil];
+}
+
++ (void)animateWithDuration:(NSTimeInterval)duration
+                 animations:(void (^)(void))animations
+                 completion:(void (^)(BOOL))completion {
+  [self animateWithDuration:duration
+                      delay:UIViewAnimationOptionCurveEaseInOut
+                    options:0
+                 animations:animations
+                 completion:completion];
+}
+
++ (void)animateWithDuration:(NSTimeInterval)duration
+                      delay:(NSTimeInterval)delay
+                    options:(UIViewAnimationOptions)options
+                 animations:(void (^ __nonnull)(void))animations
+                 completion:(void (^ __nullable)(BOOL finished))completion {
+  MDMMotionAnimator *animator = [[[self class] alloc] init];
+  MDMAnimationTraits *traits = [[MDMAnimationTraits alloc] initWithDuration:duration];
+  traits.delay = delay;
+  if ((options & UIViewAnimationOptionCurveEaseIn) == UIViewAnimationOptionCurveEaseIn) {
+    traits.timingCurve = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseIn];
+  } else if ((options & UIViewAnimationOptionCurveEaseOut) == UIViewAnimationOptionCurveEaseOut) {
+    traits.timingCurve = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
+  } else if ((options & UIViewAnimationOptionCurveLinear) == UIViewAnimationOptionCurveLinear) {
+    traits.timingCurve = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
+  }
+  [animator animateWithTraits:traits animations:animations completion:completion];
+}
+
++ (void)animateWithDuration:(NSTimeInterval)duration
+                      delay:(NSTimeInterval)delay
+     usingSpringWithDamping:(CGFloat)dampingRatio
+      initialSpringVelocity:(CGFloat)velocity
+                    options:(UIViewAnimationOptions)options
+                 animations:(void (^)(void))animations
+                 completion:(void (^)(BOOL))completion {
+  MDMMotionAnimator *animator = [[[self class] alloc] init];
+  MDMAnimationTraits *traits = [[MDMAnimationTraits alloc] initWithDuration:duration];
+  traits.delay = delay;
+  traits.timingCurve =
+      [[MDMSpringTimingCurveGenerator alloc] initWithDuration:duration
+                                                 dampingRatio:dampingRatio
+                                              initialVelocity:velocity];
+  [animator animateWithTraits:traits animations:animations completion:completion];
+}
+
 #pragma mark - Legacy
 
 - (void)animateWithTiming:(MDMMotionTiming)timing animations:(void (^)(void))animations {

--- a/tests/unit/MotionAnimatorBehavioralTests.swift
+++ b/tests/unit/MotionAnimatorBehavioralTests.swift
@@ -171,5 +171,4 @@ class AnimatorBehavioralTests: XCTestCase {
       layer.removeFromSuperlayer()
     }
   }
-
 }

--- a/tests/unit/MotionAnimatorBehavioralTests.swift
+++ b/tests/unit/MotionAnimatorBehavioralTests.swift
@@ -154,4 +154,22 @@ class AnimatorBehavioralTests: XCTestCase {
     }
   }
 
+  func testAllKeyPathsImplicitlyAnimateWithHeadlessLayerWithUIKitAPI() {
+    for (keyPath, value) in properties {
+      let layer = CAShapeLayer()
+      window.layer.addSublayer(layer)
+
+      // Connect our layers to the render server.
+      CATransaction.flush()
+
+      MotionAnimator.animate(withDuration: 0.5, animations: {
+        layer.setValue(value, forKeyPath: keyPath.rawValue)
+      })
+
+      XCTAssertNotNil(layer.animationKeys(), "Expected \(keyPath.rawValue) to generate animations")
+
+      layer.removeFromSuperlayer()
+    }
+  }
+
 }

--- a/tests/unit/UIKitBehavioralTests.swift
+++ b/tests/unit/UIKitBehavioralTests.swift
@@ -61,6 +61,7 @@ class UIKitBehavioralTests: XCTestCase {
     let oldSuperview = view.superview!
     view.removeFromSuperview()
     view = ShapeLayerBackedView() // Need to animate a view's layer to get implicit animations.
+    view.layer.anchorPoint = .zero
     oldSuperview.addSubview(view)
 
     // Connect our layers to the render server.
@@ -71,15 +72,7 @@ class UIKitBehavioralTests: XCTestCase {
 
   func testSomePropertiesImplicitlyAnimateAdditively() {
     let baselineProperties: [AnimatableKeyPath: Any] = [
-      .bounds: CGRect(x: 0, y: 0, width: 123, height: 456),
       .height: 100,
-      .position: CGPoint(x: 50, y: 20),
-      .rotation: 42,
-      .scale: 2.5,
-      .transform: CGAffineTransform(scaleX: 1.5, y: 1.5),
-      .width: 25,
-      .x: 12,
-      .y: 23,
     ]
     let properties: [AnimatableKeyPath: Any]
     if #available(iOS 11.0, *) {

--- a/tests/unit/UIKitEquivalencyTests.swift
+++ b/tests/unit/UIKitEquivalencyTests.swift
@@ -1,0 +1,124 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+#if IS_BAZEL_BUILD
+import _MotionAnimator
+#else
+import MotionAnimator
+#endif
+
+class UIKitEquivalencyTests: XCTestCase {
+  var view: UIView!
+
+  var originalImplementation: IMP?
+  override func setUp() {
+    super.setUp()
+
+    let window = UIWindow()
+    window.makeKeyAndVisible()
+    view = ShapeLayerBackedView()
+    window.addSubview(view)
+
+    rebuildView()
+  }
+
+  override func tearDown() {
+    view = nil
+
+    super.tearDown()
+  }
+
+  private func rebuildView() {
+    let oldSuperview = view.superview!
+    view.removeFromSuperview()
+    view = ShapeLayerBackedView() // Need to animate a view's layer to get implicit animations.
+    view.layer.anchorPoint = .zero // Needed to ensure that animating the width/height don't also
+    oldSuperview.addSubview(view)
+
+    // Connect our layers to the render server.
+    CATransaction.flush()
+  }
+
+  // MARK: Each animatable property needs to be added to exactly one of the following three tests
+
+  func testMostPropertiesImplicitlyAnimateAdditively() {
+    let baselineProperties: [AnimatableKeyPath: Any] = [
+      .cornerRadius: 3,
+      .position: CGPoint(x: 50, y: 20),
+      .rotation: 42,
+      .scale: 2.5,
+      .shadowOffset: CGSize(width: 1, height: 1),
+      .shadowOpacity: 0.3,
+      .shadowRadius: 5,
+      .strokeStart: 0.2,
+      .strokeEnd: 0.5,
+      .transform: CGAffineTransform(scaleX: 1.5, y: 1.5),
+      .x: 12,
+      .y: 23,
+
+      // Should animate additively, but blocked by
+      // https://github.com/material-motion/motion-animator-objc/issues/74
+      //.bounds: CGRect(x: 0, y: 0, width: 123, height: 456),
+      //.height: 100,
+      //.width: 25,
+    ]
+    for (keyPath, value) in baselineProperties {
+      rebuildView()
+
+      MotionAnimator.animate(withDuration: 0.01) {
+        self.view.layer.setValue(value, forKeyPath: keyPath.rawValue)
+      }
+
+      XCTAssertNotNil(view.layer.animationKeys(),
+                      "Expected \(keyPath.rawValue) to generate at least one animation.")
+      if let animationKeys = view.layer.animationKeys() {
+        for key in animationKeys {
+          let animation = view.layer.animation(forKey: key) as! CABasicAnimation
+          XCTAssertTrue(animation.isAdditive,
+                        "Expected \(key) to be additive as a result of animating "
+                        + "\(keyPath.rawValue), but it was not: \(animation.debugDescription).")
+        }
+      }
+    }
+  }
+
+  func testSomePropertiesImplicitlyAnimateButNotAdditively() {
+    let baselineProperties: [AnimatableKeyPath: Any] = [
+      .backgroundColor: UIColor.blue,
+      .opacity: 0.5,
+    ]
+    for (keyPath, value) in baselineProperties {
+      rebuildView()
+
+      MotionAnimator.animate(withDuration: 0.01) {
+        self.view.layer.setValue(value, forKeyPath: keyPath.rawValue)
+      }
+
+      XCTAssertNotNil(view.layer.animationKeys(),
+                      "Expected \(keyPath.rawValue) to generate at least one animation.")
+      if let animationKeys = view.layer.animationKeys() {
+        for key in animationKeys {
+          let animation = view.layer.animation(forKey: key) as! CABasicAnimation
+          XCTAssertFalse(animation.isAdditive,
+                        "Expected \(key) not to be additive as a result of animating "
+                        + "\(keyPath.rawValue), but it was: \(animation.debugDescription).")
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This will enable easier migrations from existing UIKit code paths while allowing clients to benefit from the increased support for implicitly animatable properties.