### PR TITLE
Fix crash in Legacy API for nil completion blocks

### DIFF
--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -261,7 +261,9 @@
                completion:(void (^)(void))completion {
   MDMAnimationTraits *traits = [[MDMAnimationTraits alloc] initWithMotionTiming:timing];
   [self animateWithTraits:traits animations:animations completion:^(BOOL didComplete) {
-    completion();
+    if (completion) {
+      completion();
+    }
   }];
 }
 
@@ -284,8 +286,10 @@
                     layer:layer
                   keyPath:keyPath
                completion:^(BOOL didComplete) {
-    completion();
-  }];
+                 if (completion) {
+                   completion();
+                 }
+               }];
 }
 
 #pragma mark - Private

--- a/tests/unit/MotionAnimatorTests.m
+++ b/tests/unit/MotionAnimatorTests.m
@@ -166,4 +166,47 @@
   XCTAssertTrue(didAddAnimation);
 }
 
+#pragma mark - Legacy API
+
+- (void)testAnimationWithTimingNilCompletion {
+  // Given
+  MDMMotionAnimator *animator = [[MDMMotionAnimator alloc] init];
+
+  CALayer *layer = [[CALayer alloc] init];
+  MDMMotionTiming timing = (MDMMotionTiming) {
+    .duration = 0.250, .curve = MDMMotionCurveMakeBezier(0.42f, 0.00f, 0.58f, 1.00f)
+  };
+
+  // When
+  [animator animateWithTiming:timing
+                   animations:^{
+                     layer.opacity = 0.7;
+                   }
+                   completion:nil];
+
+  // Then
+  XCTAssertEqualWithAccuracy(layer.opacity, 0.7, 0.0001);
+}
+
+- (void)testAnimationWithTimingToLayerWithValuesKeyPathNilCompletion {
+  // Given
+  MDMMotionAnimator *animator = [[MDMMotionAnimator alloc] init];
+
+  CALayer *layer = [[CALayer alloc] init];
+  CALayer *anotherLayer = [[CALayer alloc] init];
+  MDMMotionTiming timing = (MDMMotionTiming) {
+    .duration = 0.250, .curve = MDMMotionCurveMakeBezier(0.42f, 0.00f, 0.58f, 1.00f)
+  };
+
+  // When
+  [animator animateWithTiming:timing
+                       toLayer:anotherLayer
+                    withValues:@[@(0), @(1)]
+                      keyPath:@"opacity"
+                   completion:nil];
+
+  // Then
+  XCTAssertEqualWithAccuracy(layer.opacity, 1, 0.0001);
+}
+
 @end


### PR DESCRIPTION
When passed a `nil` completion block value, the "legacy" API would crash
by calling the block without performing a nil check.  Adding 2 tests to
verify that the animation works as expected with a `nil` completion
block.

Fixes #111