### PR TITLE
Reduce flakiness in UIKitBehavioralTests.

### DIFF
--- a/examples/apps/Catalog/MotionAnimatorCatalog.xcodeproj/project.pbxproj
+++ b/examples/apps/Catalog/MotionAnimatorCatalog.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		664F59981FCE5CE2002EC56D /* BeginFromCurrentStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664F59971FCE5CE2002EC56D /* BeginFromCurrentStateTests.swift */; };
 		664F599A1FCE6661002EC56D /* NonAdditiveAnimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664F59991FCE6661002EC56D /* NonAdditiveAnimatorTests.swift */; };
 		664F599C1FCE67DB002EC56D /* AdditiveAnimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664F599B1FCE67DB002EC56D /* AdditiveAnimatorTests.swift */; };
+		666696D0204E0B78008D9B67 /* WindowManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666696CF204E0B78008D9B67 /* WindowManagement.swift */; };
 		666FAA841D384A6B000363DA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666FAA831D384A6B000363DA /* AppDelegate.swift */; };
 		666FAA8B1D384A6B000363DA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 666FAA8A1D384A6B000363DA /* Assets.xcassets */; };
 		666FAA8E1D384A6B000363DA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 666FAA8C1D384A6B000363DA /* LaunchScreen.storyboard */; };
@@ -68,6 +69,7 @@
 		664F59971FCE5CE2002EC56D /* BeginFromCurrentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeginFromCurrentStateTests.swift; sourceTree = "<group>"; };
 		664F59991FCE6661002EC56D /* NonAdditiveAnimatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAdditiveAnimatorTests.swift; sourceTree = "<group>"; };
 		664F599B1FCE67DB002EC56D /* AdditiveAnimatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdditiveAnimatorTests.swift; sourceTree = "<group>"; };
+		666696CF204E0B78008D9B67 /* WindowManagement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WindowManagement.swift; sourceTree = "<group>"; };
 		666FAA801D384A6B000363DA /* MotionAnimatorCatalog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MotionAnimatorCatalog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		666FAA831D384A6B000363DA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Catalog/AppDelegate.swift; sourceTree = "<group>"; };
 		666FAA8A1D384A6B000363DA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -252,6 +254,7 @@
 				660636011FACC24300C3DFB8 /* TimeScaleFactorTests.swift */,
 				664F59931FCCE27E002EC56D /* UIKitBehavioralTests.swift */,
 				668819F91FE2EB36003A9420 /* UIKitEquivalencyTests.swift */,
+				666696CF204E0B78008D9B67 /* WindowManagement.swift */,
 			);
 			path = unit;
 			sourceTree = "<group>";
@@ -542,6 +545,7 @@
 				66A6A6681FBA158000DE54CB /* AnimationRemovalTests.swift in Sources */,
 				6687264A1EF04B4C00113675 /* MotionAnimatorTests.swift in Sources */,
 				664F59981FCE5CE2002EC56D /* BeginFromCurrentStateTests.swift in Sources */,
+				666696D0204E0B78008D9B67 /* WindowManagement.swift in Sources */,
 				66FD99FA1EE9FBBE00C53A82 /* MotionAnimatorTests.m in Sources */,
 				669B6CA91FD0547100B80B76 /* MotionAnimatorBehavioralTests.swift in Sources */,
 				668819FA1FE2EB36003A9420 /* UIKitEquivalencyTests.swift in Sources */,

--- a/tests/unit/AdditiveAnimatorTests.swift
+++ b/tests/unit/AdditiveAnimatorTests.swift
@@ -35,8 +35,7 @@ class AdditiveAnimationTests: XCTestCase {
 
     traits = MDMAnimationTraits(duration: 1)
 
-    let window = UIWindow()
-    window.makeKeyAndVisible()
+    let window = getTestHarnessKeyWindow()
     view = UIView() // Need to animate a view's layer to get implicit animations.
     window.addSubview(view)
 

--- a/tests/unit/AnimationRemovalTests.swift
+++ b/tests/unit/AnimationRemovalTests.swift
@@ -27,15 +27,13 @@ class AnimationRemovalTests: XCTestCase {
   var traits: MDMAnimationTraits!
   var view: UIView!
 
-  var originalImplementation: IMP?
   override func setUp() {
     super.setUp()
 
     animator = MotionAnimator()
     traits = MDMAnimationTraits(duration: 1)
 
-    let window = UIWindow()
-    window.makeKeyAndVisible()
+    let window = getTestHarnessKeyWindow()
     view = UIView() // Need to animate a view's layer to get implicit animations.
     window.addSubview(view)
 

--- a/tests/unit/BeginFromCurrentStateTests.swift
+++ b/tests/unit/BeginFromCurrentStateTests.swift
@@ -37,8 +37,7 @@ class BeginFromCurrentStateTests: XCTestCase {
 
     traits = MDMAnimationTraits(duration: 1)
 
-    let window = UIWindow()
-    window.makeKeyAndVisible()
+    let window = getTestHarnessKeyWindow()
     view = UIView() // Need to animate a view's layer to get implicit animations.
     window.addSubview(view)
 

--- a/tests/unit/HeadlessLayerImplicitAnimationTests.swift
+++ b/tests/unit/HeadlessLayerImplicitAnimationTests.swift
@@ -33,8 +33,7 @@ class HeadlessLayerImplicitAnimationTests: XCTestCase {
   override func setUp() {
     super.setUp()
 
-    window = UIWindow()
-    window.makeKeyAndVisible()
+    window = getTestHarnessKeyWindow()
 
     layer = CALayer()
 

--- a/tests/unit/ImplicitAnimationTests.swift
+++ b/tests/unit/ImplicitAnimationTests.swift
@@ -36,8 +36,7 @@ class ImplicitAnimationTests: XCTestCase {
 
     traits = MDMAnimationTraits(duration: 1)
 
-    let window = UIWindow()
-    window.makeKeyAndVisible()
+    let window = getTestHarnessKeyWindow()
     view = UIView() // Need to animate a view's layer to get implicit animations.
     window.addSubview(view)
 

--- a/tests/unit/InstantAnimationTests.swift
+++ b/tests/unit/InstantAnimationTests.swift
@@ -32,8 +32,7 @@ class InstantAnimationTests: XCTestCase {
 
     animator = MotionAnimator()
 
-    let window = UIWindow()
-    window.makeKeyAndVisible()
+    let window = getTestHarnessKeyWindow()
     view = UIView() // Need to animate a view's layer to get implicit animations.
     window.addSubview(view)
 

--- a/tests/unit/MotionAnimatorBehavioralTests.swift
+++ b/tests/unit/MotionAnimatorBehavioralTests.swift
@@ -29,8 +29,7 @@ class AnimatorBehavioralTests: XCTestCase {
   override func setUp() {
     super.setUp()
 
-    window = UIWindow()
-    window.makeKeyAndVisible()
+    window = getTestHarnessKeyWindow()
 
     traits = MDMAnimationTraits(duration: 1)
   }

--- a/tests/unit/MotionAnimatorTests.swift
+++ b/tests/unit/MotionAnimatorTests.swift
@@ -29,8 +29,7 @@ class MotionAnimatorTests: XCTestCase {
     animator.additive = false
     let traits = MDMAnimationTraits(duration: 1)
 
-    let window = UIWindow()
-    window.makeKeyAndVisible()
+    let window = getTestHarnessKeyWindow()
     let view = UIView() // Need to animate a view's layer to get implicit animations.
     window.addSubview(view)
 

--- a/tests/unit/NonAdditiveAnimatorTests.swift
+++ b/tests/unit/NonAdditiveAnimatorTests.swift
@@ -35,8 +35,7 @@ class NonAdditiveAnimationTests: XCTestCase {
 
     traits = MDMAnimationTraits(duration: 1)
 
-    let window = UIWindow()
-    window.makeKeyAndVisible()
+    let window = getTestHarnessKeyWindow()
     view = UIView() // Need to animate a view's layer to get implicit animations.
     window.addSubview(view)
 

--- a/tests/unit/QuartzCoreBehavioralTests.swift
+++ b/tests/unit/QuartzCoreBehavioralTests.swift
@@ -29,8 +29,7 @@ class QuartzCoreBehavioralTests: XCTestCase {
   override func setUp() {
     super.setUp()
 
-    window = UIWindow()
-    window.makeKeyAndVisible()
+    window = getTestHarnessKeyWindow()
   }
 
   override func tearDown() {

--- a/tests/unit/SpringTimingCurveTests.swift
+++ b/tests/unit/SpringTimingCurveTests.swift
@@ -33,8 +33,7 @@ class SpringTimingCurveTests: XCTestCase {
     animator = MotionAnimator()
     traits = MDMAnimationTraits(duration: 1)
 
-    let window = UIWindow()
-    window.makeKeyAndVisible()
+    let window = getTestHarnessKeyWindow()
     view = UIView() // Need to animate a view's layer to get implicit animations.
     window.addSubview(view)
 

--- a/tests/unit/UIKitBehavioralTests.swift
+++ b/tests/unit/UIKitBehavioralTests.swift
@@ -38,31 +38,28 @@ class ShapeLayerBackedView: UIView {
 
 class UIKitBehavioralTests: XCTestCase {
   var view: UIView!
+  var window: UIWindow!
 
-  var originalImplementation: IMP?
   override func setUp() {
     super.setUp()
 
-    let window = UIWindow()
-    window.makeKeyAndVisible()
-    view = ShapeLayerBackedView()
-    window.addSubview(view)
+    window = getTestHarnessKeyWindow()
 
     rebuildView()
   }
 
   override func tearDown() {
     view = nil
+    window = nil
 
     super.tearDown()
   }
 
   private func rebuildView() {
-    let oldSuperview = view.superview!
-    view.removeFromSuperview()
+    window.subviews.forEach { $0.removeFromSuperview() }
     view = ShapeLayerBackedView() // Need to animate a view's layer to get implicit animations.
     view.layer.anchorPoint = .zero
-    oldSuperview.addSubview(view)
+    window.addSubview(view)
 
     // Connect our layers to the render server.
     CATransaction.flush()

--- a/tests/unit/UIKitEquivalencyTests.swift
+++ b/tests/unit/UIKitEquivalencyTests.swift
@@ -23,13 +23,13 @@ import MotionAnimator
 
 class UIKitEquivalencyTests: XCTestCase {
   var view: UIView!
+  var window: UIWindow!
 
   var originalImplementation: IMP?
   override func setUp() {
     super.setUp()
 
-    let window = UIWindow()
-    window.makeKeyAndVisible()
+    window = getTestHarnessKeyWindow()
     view = ShapeLayerBackedView()
     window.addSubview(view)
 
@@ -38,16 +38,16 @@ class UIKitEquivalencyTests: XCTestCase {
 
   override func tearDown() {
     view = nil
+    window = nil
 
     super.tearDown()
   }
 
   private func rebuildView() {
-    let oldSuperview = view.superview!
     view.removeFromSuperview()
     view = ShapeLayerBackedView() // Need to animate a view's layer to get implicit animations.
-    view.layer.anchorPoint = .zero // Needed to ensure that animating the width/height don't also
-    oldSuperview.addSubview(view)
+    view.layer.anchorPoint = .zero
+    window.addSubview(view)
 
     // Connect our layers to the render server.
     CATransaction.flush()

--- a/tests/unit/WindowManagement.swift
+++ b/tests/unit/WindowManagement.swift
@@ -1,0 +1,35 @@
+/*
+ Copyright 2018-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+import UIKit
+
+// Certain test targets (UIKitBehavioralTests's
+// testDefaultsAnimatesPositionAdditivelyFromItsModelLayerState and
+// testBeginFromCurrentStateAnimatesPositionAdditivelyFromItsModelLayerState) become flaky on iOS
+// 8.1 when multiple UIWindow instances are created across multiple tests. Reusing the same key
+// window between test instances reduces this flakiness and improves the testing performance
+// by a factor of 3 (from ~30s to ~10s overall test time).
+func getTestHarnessKeyWindow() -> UIWindow {
+  let window: UIWindow
+  if let keyWindow = UIApplication.shared.keyWindow {
+    window = keyWindow
+  } else {
+    window = UIWindow()
+    window.makeKeyAndVisible()
+  }
+  return window
+}


### PR DESCRIPTION
Certain test targets (UIKitBehavioralTests's `testDefaultsAnimatesPositionAdditivelyFromItsModelLayerState` and `testBeginFromCurrentStateAnimatesPositionAdditivelyFromItsModelLayerState`) become flaky on iOS 8.1 when multiple UIWindow instances are created across multiple tests. Reusing the same key window between test instances reduces this flakiness and improves the testing performance by a factor of 3 (from ~30s to ~10s overall test time).