### PR TITLE
Don't animate system views with the animator.

### DIFF
--- a/examples/CalendarCardExpansionExample.m
+++ b/examples/CalendarCardExpansionExample.m
@@ -48,9 +48,7 @@
   animator.shouldReverseValues = !_expanded;
   animator.beginFromCurrentState = YES;
 
-  [animator animateWithTraits:traits.navigationBarY animations:^{
-    [self.navigationController setNavigationBarHidden:_expanded animated:YES];
-  }];
+  [self.navigationController setNavigationBarHidden:_expanded animated:YES];
 
   CGRect chipFrame = [self frameForChip];
   CGRect headerFrame = [self frameForHeader];

--- a/examples/CalendarChipMotionSpec.h
+++ b/examples/CalendarChipMotionSpec.h
@@ -26,8 +26,6 @@
 @property(nonatomic, strong, nonnull, readonly) MDMAnimationTraits *chipContentOpacity;
 @property(nonatomic, strong, nonnull, readonly) MDMAnimationTraits *headerContentOpacity;
 
-@property(nonatomic, strong, nonnull, readonly) MDMAnimationTraits *navigationBarY;
-
 @end
 
 @interface CalendarChipMotionSpec: NSObject

--- a/examples/CalendarChipMotionSpec.m
+++ b/examples/CalendarChipMotionSpec.m
@@ -80,10 +80,6 @@ static id<MDMTimingCurve> LinearTimingCurve(void) {
   return [[MDMAnimationTraits alloc] initWithDelay:0.000 duration:0.075 timingCurve:LinearTimingCurve()];
 }
 
-- (MDMAnimationTraits *)navigationBarY {
-  return [[MDMAnimationTraits alloc] initWithDelay:0.045 duration:0.150 timingCurve:StandardTimingCurve()];
-}
-
 @end
 
 @implementation CalendarChipMotionSpec


### PR DESCRIPTION
Notably, animating the status bar with the animator can cause all of the status bar elements to animate. This is not desirable and deviant from UIKit's implicit animator behavior, but at this time I don't see a way to mimic the same behavior without regressing on our support for animating unhosted layers.