### PR TITLE
Resolve a static analyzer warning.

### DIFF
--- a/src/private/MDMAnimationRegistrar.h
+++ b/src/private/MDMAnimationRegistrar.h
@@ -25,7 +25,7 @@
 // executed.
 - (void)addAnimation:(nonnull CABasicAnimation *)animation
              toLayer:(nonnull CALayer *)layer
-              forKey:(nonnull NSString *)key
+              forKey:(nullable NSString *)key
           completion:(void(^ __nullable)(BOOL))completion;
 
 // For every active animation, reads the associated layer's presentation layer key path and writes


### PR DESCRIPTION
The warning was:

    nil passed to a callee that requires a non-null 3rd parameter

This warning was correctly identifying that the public API for the animator was mis-typed as nonnull. The API has been updated to reflect the fact that a nil value is accepted.