### PR TITLE
[WIP] Adding Carthage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+.DS_Store
+Carthage

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "material-motion/motion-interchange-objc" ~> 3.0

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>4.0.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/MotionAnimator.xcodeproj/project.pbxproj
+++ b/MotionAnimator.xcodeproj/project.pbxproj
@@ -1,0 +1,439 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		6DC6503122388AC6003DBBF5 /* MDMMotionAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6501A22388AC6003DBBF5 /* MDMMotionAnimator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6503222388AC6003DBBF5 /* MDMCoreAnimationTraceable.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6501B22388AC6003DBBF5 /* MDMCoreAnimationTraceable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6503322388AC6003DBBF5 /* MDMAnimatableKeyPaths.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6501C22388AC6003DBBF5 /* MDMAnimatableKeyPaths.m */; };
+		6DC6503422388AC6003DBBF5 /* MotionAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6501D22388AC6003DBBF5 /* MotionAnimator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6503522388AC6003DBBF5 /* CATransaction+MotionAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6501E22388AC6003DBBF5 /* CATransaction+MotionAnimator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6503622388AC6003DBBF5 /* MDMMotionAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6501F22388AC6003DBBF5 /* MDMMotionAnimator.m */; };
+		6DC6503722388AC6003DBBF5 /* CAMediaTimingFunction+MotionAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6502122388AC6003DBBF5 /* CAMediaTimingFunction+MotionAnimator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6DC6503822388AC6003DBBF5 /* MDMUIKitValueCoercion.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6502222388AC6003DBBF5 /* MDMUIKitValueCoercion.m */; };
+		6DC6503922388AC6003DBBF5 /* MDMRegisteredAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6502322388AC6003DBBF5 /* MDMRegisteredAnimation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6DC6503A22388AC6003DBBF5 /* CABasicAnimation+MotionAnimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6502422388AC6003DBBF5 /* CABasicAnimation+MotionAnimator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6DC6503B22388AC6003DBBF5 /* MDMAnimationRegistrar.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6502522388AC6003DBBF5 /* MDMAnimationRegistrar.m */; };
+		6DC6503C22388AC6003DBBF5 /* MDMDragCoefficient.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6502622388AC6003DBBF5 /* MDMDragCoefficient.m */; };
+		6DC6503D22388AC6003DBBF5 /* MDMBlockAnimations.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6502722388AC6003DBBF5 /* MDMBlockAnimations.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6DC6503E22388AC6003DBBF5 /* CAMediaTimingFunction+MotionAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6502822388AC6003DBBF5 /* CAMediaTimingFunction+MotionAnimator.m */; };
+		6DC6503F22388AC6003DBBF5 /* MDMUIKitValueCoercion.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6502922388AC6003DBBF5 /* MDMUIKitValueCoercion.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6DC6504022388AC6003DBBF5 /* MDMDragCoefficient.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6502A22388AC6003DBBF5 /* MDMDragCoefficient.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6DC6504122388AC6003DBBF5 /* MDMAnimationRegistrar.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6502B22388AC6003DBBF5 /* MDMAnimationRegistrar.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6DC6504222388AC6003DBBF5 /* CABasicAnimation+MotionAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6502C22388AC6003DBBF5 /* CABasicAnimation+MotionAnimator.m */; };
+		6DC6504322388AC6003DBBF5 /* MDMRegisteredAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6502D22388AC6003DBBF5 /* MDMRegisteredAnimation.m */; };
+		6DC6504422388AC6003DBBF5 /* MDMBlockAnimations.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6502E22388AC6003DBBF5 /* MDMBlockAnimations.m */; };
+		6DC6504522388AC6003DBBF5 /* MDMAnimatableKeyPaths.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6502F22388AC6003DBBF5 /* MDMAnimatableKeyPaths.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6504622388AC6003DBBF5 /* CATransaction+MotionAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6503022388AC6003DBBF5 /* CATransaction+MotionAnimator.m */; };
+		6DC6508B22388FD6003DBBF5 /* MotionInterchange.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC6508A22388FD6003DBBF5 /* MotionInterchange.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		6DC6500E22388A5E003DBBF5 /* MotionAnimator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MotionAnimator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6DC6501A22388AC6003DBBF5 /* MDMMotionAnimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMMotionAnimator.h; sourceTree = "<group>"; };
+		6DC6501B22388AC6003DBBF5 /* MDMCoreAnimationTraceable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMCoreAnimationTraceable.h; sourceTree = "<group>"; };
+		6DC6501C22388AC6003DBBF5 /* MDMAnimatableKeyPaths.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDMAnimatableKeyPaths.m; sourceTree = "<group>"; };
+		6DC6501D22388AC6003DBBF5 /* MotionAnimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MotionAnimator.h; sourceTree = "<group>"; };
+		6DC6501E22388AC6003DBBF5 /* CATransaction+MotionAnimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CATransaction+MotionAnimator.h"; sourceTree = "<group>"; };
+		6DC6501F22388AC6003DBBF5 /* MDMMotionAnimator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDMMotionAnimator.m; sourceTree = "<group>"; };
+		6DC6502122388AC6003DBBF5 /* CAMediaTimingFunction+MotionAnimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CAMediaTimingFunction+MotionAnimator.h"; sourceTree = "<group>"; };
+		6DC6502222388AC6003DBBF5 /* MDMUIKitValueCoercion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDMUIKitValueCoercion.m; sourceTree = "<group>"; };
+		6DC6502322388AC6003DBBF5 /* MDMRegisteredAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMRegisteredAnimation.h; sourceTree = "<group>"; };
+		6DC6502422388AC6003DBBF5 /* CABasicAnimation+MotionAnimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CABasicAnimation+MotionAnimator.h"; sourceTree = "<group>"; };
+		6DC6502522388AC6003DBBF5 /* MDMAnimationRegistrar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDMAnimationRegistrar.m; sourceTree = "<group>"; };
+		6DC6502622388AC6003DBBF5 /* MDMDragCoefficient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDMDragCoefficient.m; sourceTree = "<group>"; };
+		6DC6502722388AC6003DBBF5 /* MDMBlockAnimations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMBlockAnimations.h; sourceTree = "<group>"; };
+		6DC6502822388AC6003DBBF5 /* CAMediaTimingFunction+MotionAnimator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CAMediaTimingFunction+MotionAnimator.m"; sourceTree = "<group>"; };
+		6DC6502922388AC6003DBBF5 /* MDMUIKitValueCoercion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMUIKitValueCoercion.h; sourceTree = "<group>"; };
+		6DC6502A22388AC6003DBBF5 /* MDMDragCoefficient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMDragCoefficient.h; sourceTree = "<group>"; };
+		6DC6502B22388AC6003DBBF5 /* MDMAnimationRegistrar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMAnimationRegistrar.h; sourceTree = "<group>"; };
+		6DC6502C22388AC6003DBBF5 /* CABasicAnimation+MotionAnimator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CABasicAnimation+MotionAnimator.m"; sourceTree = "<group>"; };
+		6DC6502D22388AC6003DBBF5 /* MDMRegisteredAnimation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDMRegisteredAnimation.m; sourceTree = "<group>"; };
+		6DC6502E22388AC6003DBBF5 /* MDMBlockAnimations.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDMBlockAnimations.m; sourceTree = "<group>"; };
+		6DC6502F22388AC6003DBBF5 /* MDMAnimatableKeyPaths.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMAnimatableKeyPaths.h; sourceTree = "<group>"; };
+		6DC6503022388AC6003DBBF5 /* CATransaction+MotionAnimator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CATransaction+MotionAnimator.m"; sourceTree = "<group>"; };
+		6DC6504722388C45003DBBF5 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
+		6DC6508A22388FD6003DBBF5 /* MotionInterchange.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MotionInterchange.framework; path = Carthage/Build/iOS/MotionInterchange.framework; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		6DC6500B22388A5E003DBBF5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6DC6508B22388FD6003DBBF5 /* MotionInterchange.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		6DC6500422388A5E003DBBF5 = {
+			isa = PBXGroup;
+			children = (
+				6DC6501922388AC6003DBBF5 /* src */,
+				6DC6500F22388A5E003DBBF5 /* Products */,
+				6DC6508922388FD6003DBBF5 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		6DC6500F22388A5E003DBBF5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				6DC6500E22388A5E003DBBF5 /* MotionAnimator.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		6DC6501922388AC6003DBBF5 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				6DC6504722388C45003DBBF5 /* Info.plist */,
+				6DC6501E22388AC6003DBBF5 /* CATransaction+MotionAnimator.h */,
+				6DC6503022388AC6003DBBF5 /* CATransaction+MotionAnimator.m */,
+				6DC6502F22388AC6003DBBF5 /* MDMAnimatableKeyPaths.h */,
+				6DC6501C22388AC6003DBBF5 /* MDMAnimatableKeyPaths.m */,
+				6DC6501B22388AC6003DBBF5 /* MDMCoreAnimationTraceable.h */,
+				6DC6501A22388AC6003DBBF5 /* MDMMotionAnimator.h */,
+				6DC6501F22388AC6003DBBF5 /* MDMMotionAnimator.m */,
+				6DC6501D22388AC6003DBBF5 /* MotionAnimator.h */,
+				6DC6502022388AC6003DBBF5 /* private */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		6DC6502022388AC6003DBBF5 /* private */ = {
+			isa = PBXGroup;
+			children = (
+				6DC6502422388AC6003DBBF5 /* CABasicAnimation+MotionAnimator.h */,
+				6DC6502C22388AC6003DBBF5 /* CABasicAnimation+MotionAnimator.m */,
+				6DC6502122388AC6003DBBF5 /* CAMediaTimingFunction+MotionAnimator.h */,
+				6DC6502822388AC6003DBBF5 /* CAMediaTimingFunction+MotionAnimator.m */,
+				6DC6502B22388AC6003DBBF5 /* MDMAnimationRegistrar.h */,
+				6DC6502522388AC6003DBBF5 /* MDMAnimationRegistrar.m */,
+				6DC6502722388AC6003DBBF5 /* MDMBlockAnimations.h */,
+				6DC6502E22388AC6003DBBF5 /* MDMBlockAnimations.m */,
+				6DC6502A22388AC6003DBBF5 /* MDMDragCoefficient.h */,
+				6DC6502622388AC6003DBBF5 /* MDMDragCoefficient.m */,
+				6DC6502322388AC6003DBBF5 /* MDMRegisteredAnimation.h */,
+				6DC6502D22388AC6003DBBF5 /* MDMRegisteredAnimation.m */,
+				6DC6502922388AC6003DBBF5 /* MDMUIKitValueCoercion.h */,
+				6DC6502222388AC6003DBBF5 /* MDMUIKitValueCoercion.m */,
+			);
+			path = private;
+			sourceTree = "<group>";
+		};
+		6DC6508922388FD6003DBBF5 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				6DC6508A22388FD6003DBBF5 /* MotionInterchange.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		6DC6500922388A5E003DBBF5 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6DC6503122388AC6003DBBF5 /* MDMMotionAnimator.h in Headers */,
+				6DC6503422388AC6003DBBF5 /* MotionAnimator.h in Headers */,
+				6DC6503522388AC6003DBBF5 /* CATransaction+MotionAnimator.h in Headers */,
+				6DC6503222388AC6003DBBF5 /* MDMCoreAnimationTraceable.h in Headers */,
+				6DC6504522388AC6003DBBF5 /* MDMAnimatableKeyPaths.h in Headers */,
+				6DC6504022388AC6003DBBF5 /* MDMDragCoefficient.h in Headers */,
+				6DC6504122388AC6003DBBF5 /* MDMAnimationRegistrar.h in Headers */,
+				6DC6503F22388AC6003DBBF5 /* MDMUIKitValueCoercion.h in Headers */,
+				6DC6503922388AC6003DBBF5 /* MDMRegisteredAnimation.h in Headers */,
+				6DC6503A22388AC6003DBBF5 /* CABasicAnimation+MotionAnimator.h in Headers */,
+				6DC6503D22388AC6003DBBF5 /* MDMBlockAnimations.h in Headers */,
+				6DC6503722388AC6003DBBF5 /* CAMediaTimingFunction+MotionAnimator.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		6DC6500D22388A5E003DBBF5 /* MotionAnimator */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6DC6501622388A5E003DBBF5 /* Build configuration list for PBXNativeTarget "MotionAnimator" */;
+			buildPhases = (
+				6DC6500922388A5E003DBBF5 /* Headers */,
+				6DC6500A22388A5E003DBBF5 /* Sources */,
+				6DC6500B22388A5E003DBBF5 /* Frameworks */,
+				6DC6500C22388A5E003DBBF5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MotionAnimator;
+			productName = MotionAnimator;
+			productReference = 6DC6500E22388A5E003DBBF5 /* MotionAnimator.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		6DC6500522388A5E003DBBF5 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1010;
+				ORGANIZATIONNAME = Google;
+				TargetAttributes = {
+					6DC6500D22388A5E003DBBF5 = {
+						CreatedOnToolsVersion = 10.1;
+					};
+				};
+			};
+			buildConfigurationList = 6DC6500822388A5E003DBBF5 /* Build configuration list for PBXProject "MotionAnimator" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 6DC6500422388A5E003DBBF5;
+			productRefGroup = 6DC6500F22388A5E003DBBF5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				6DC6500D22388A5E003DBBF5 /* MotionAnimator */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		6DC6500C22388A5E003DBBF5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		6DC6500A22388A5E003DBBF5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6DC6503322388AC6003DBBF5 /* MDMAnimatableKeyPaths.m in Sources */,
+				6DC6503822388AC6003DBBF5 /* MDMUIKitValueCoercion.m in Sources */,
+				6DC6503622388AC6003DBBF5 /* MDMMotionAnimator.m in Sources */,
+				6DC6503E22388AC6003DBBF5 /* CAMediaTimingFunction+MotionAnimator.m in Sources */,
+				6DC6503C22388AC6003DBBF5 /* MDMDragCoefficient.m in Sources */,
+				6DC6503B22388AC6003DBBF5 /* MDMAnimationRegistrar.m in Sources */,
+				6DC6504422388AC6003DBBF5 /* MDMBlockAnimations.m in Sources */,
+				6DC6504222388AC6003DBBF5 /* CABasicAnimation+MotionAnimator.m in Sources */,
+				6DC6504322388AC6003DBBF5 /* MDMRegisteredAnimation.m in Sources */,
+				6DC6504622388AC6003DBBF5 /* CATransaction+MotionAnimator.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		6DC6501422388A5E003DBBF5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		6DC6501522388A5E003DBBF5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		6DC6501722388A5E003DBBF5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.material.MotionAnimator;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		6DC6501822388A5E003DBBF5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.material.MotionAnimator;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		6DC6500822388A5E003DBBF5 /* Build configuration list for PBXProject "MotionAnimator" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6DC6501422388A5E003DBBF5 /* Debug */,
+				6DC6501522388A5E003DBBF5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6DC6501622388A5E003DBBF5 /* Build configuration list for PBXNativeTarget "MotionAnimator" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6DC6501722388A5E003DBBF5 /* Debug */,
+				6DC6501822388A5E003DBBF5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 6DC6500522388A5E003DBBF5 /* Project object */;
+}

--- a/MotionAnimator.xcodeproj/xcshareddata/xcschemes/MotionAnimator.xcscheme
+++ b/MotionAnimator.xcodeproj/xcshareddata/xcschemes/MotionAnimator.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6DC6500D22388A5E003DBBF5"
+               BuildableName = "MotionAnimator.framework"
+               BlueprintName = "MotionAnimator"
+               ReferencedContainer = "container:MotionAnimator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6DC6500D22388A5E003DBBF5"
+            BuildableName = "MotionAnimator.framework"
+            BlueprintName = "MotionAnimator"
+            ReferencedContainer = "container:MotionAnimator.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6DC6500D22388A5E003DBBF5"
+            BuildableName = "MotionAnimator.framework"
+            BlueprintName = "MotionAnimator"
+            ReferencedContainer = "container:MotionAnimator.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Adding Carthage support by creating `MotionAnimator.framework target` with it's scheme shared so that Carthage is able to find and build the shared scheme according to what is defined in the scheme.

By correctly exposing the public headers and hiding the private headers, this will also tell Xcode to build and include the correct headers available to library consumers.

Pre-requisite:
1. https://github.com/material-motion/motion-interchange-objc/pull/45 is merged
2. New tagged version is released on https://github.com/material-motion/motion-interchange-objc