### PR TITLE
v4.0.1

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,7 +1,7 @@
 module: MotionAnimator
-module_version: 4.0.0
+module_version: 4.0.1
 sdk: iphonesimulator
 umbrella_header: src/MotionAnimator.h
 objc: true
 github_url: https://github.com/material-motion/motion-animator-objc
-github_file_prefix: https://github.com/material-motion/motion-animator-objc/tree/v4.0.0
+github_file_prefix: https://github.com/material-motion/motion-animator-objc/tree/v4.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.1
+
+This patch release fixes a bug on iOS 14 affecting flickers when using animations that have no delay.
+
 # 4.0.0
 
 This major release drops official support for iOS 8 and fixes a static analyzer warning.

--- a/MotionAnimator.podspec
+++ b/MotionAnimator.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "MotionAnimator"
   s.summary      = "A Motion Animator creates performant, interruptible animations from motion specs."
-  s.version      = "4.0.0"
+  s.version      = "4.0.1"
   s.authors      = "The Material Motion Authors"
   s.license      = "Apache 2.0"
   s.homepage     = "https://github.com/material-motion/motion-animator-objc"

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - CatalogByConvention (2.5.1)
-  - MotionAnimator (4.0.0):
+  - MotionAnimator (4.0.1):
     - MotionInterchange (~> 3.0)
   - MotionInterchange (3.0.0)
 
@@ -9,7 +9,7 @@ DEPENDENCIES:
   - MotionAnimator (from `./`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - CatalogByConvention
     - MotionInterchange
 
@@ -19,9 +19,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   CatalogByConvention: 2b58a9b64e5b1049abb5d3f8e764a551bbe843a7
-  MotionAnimator: 3a22c094f2a9c21c98cee9e69b6407d1e1fff654
+  MotionAnimator: 5f99d7c9592928c0f28a66283eda9c3b657dc480
   MotionInterchange: 13adae439b377e31d1674cc165539d50e1d1566a
 
 PODFILE CHECKSUM: 3537bf01c11174928ac008c20fec4738722e96f3
 
-COCOAPODS: 1.6.0
+COCOAPODS: 1.9.3

--- a/src/MDMMotionAnimator.m
+++ b/src/MDMMotionAnimator.m
@@ -342,7 +342,20 @@
     animation.beginTime = ([layer convertTime:CACurrentMediaTime() fromLayer:nil]
                            + traits.delay * timeScaleFactor);
     animation.fillMode = kCAFillModeBackwards;
+  } else if (@available(iOS 14, *)) {
+    // iOS 14 introduced a behavioral change for animations such that they no longer appear to
+    // immediately be committed to the render server, potentially resulting in a brief flicker to
+    // the model layer's value before the animation takes effect. This could reasonably be
+    // considered a bug in iOS.
+    // To work around this, we can explicitly enforce the contract that this animation is expected
+    // to start "now" in terms of render server timing. This does mean we may lose some microseconds
+    // of animation timing at the beginning of the animation, so we only apply this on iOS 14+ where
+    // it's needed. If and when iOS fixes this bug we can remove the following line and lean on the
+    // render server choosing the appropriate start time once the animation is flushed to the render
+    // server.
+    animation.beginTime = [layer convertTime:CACurrentMediaTime() fromLayer:nil];
   }
+
 
   [_registrar addAnimation:animation toLayer:layer forKey:key completion:completion];
 }


### PR DESCRIPTION
This patch release fixes a bug on iOS 14 affecting flickers when using animations that have no delay.
